### PR TITLE
Refactor Window -> Cursor

### DIFF
--- a/src/apitest/basic_test.c
+++ b/src/apitest/basic_test.c
@@ -19,14 +19,14 @@ int main(int argc, char **argv) {
   size_t len = vimBufferGetLineCount(buf);
   assert(len == 3);
 
-  printf("cursor line: %d\n", vimWindowGetCursorLine());
+  printf("cursor line: %d\n", vimCursorGetLine());
 
-  assert(vimWindowGetCursorLine() == 1);
+  assert(vimCursorGetLine() == 1);
 
   vimInput("G");
-  printf("cursor line: %d\n", vimWindowGetCursorLine());
+  printf("cursor line: %d\n", vimCursorGetLine());
 
-  assert(vimWindowGetCursorLine() > 1);
+  assert(vimCursorGetLine() > 1);
 
   vimInput("v");
   assert(vimGetMode() & VISUAL == VISUAL);
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
   vimInput("l");
   vimInput("x");
 
-  printf("CURSOR LINE: %d\n", vimWindowGetCursorLine());
+  printf("CURSOR LINE: %d\n", vimCursorGetLine());
   /* assert(vimGetMode() & INSERT == INSERT); */
 
   line = vimBufferGetLine(buf, 1);

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -18,7 +18,7 @@ void test_teardown(void) {
 /*   vimInput("a"); */
 /*   vimInput("\033"); */
 
-/*   char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine()); */
+/*   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine()); */
 /*   printf("LINE: %s\n", line); */
 /*   mu_check(strcmp(line, "aaaaaThis is the first line of a test file") == 0); */
 /* } */
@@ -29,7 +29,7 @@ MU_TEST(insert_beginning) {
   vimInput("b");
   vimInput("c");
 
-  char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   mu_check(strcmp(line, "abcThis is the first line of a test file") == 0);
 }
 
@@ -40,10 +40,10 @@ MU_TEST(insert_cr) {
   vimInput("c");
   vimInput("<CR>");
 
-  char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   mu_check(strcmp(line, "This is the first line of a test file") == 0);
 
-  char_u *prevLine = vimBufferGetLine(curbuf, vimWindowGetCursorLine() - 1);
+  char_u *prevLine = vimBufferGetLine(curbuf, vimCursorGetLine() - 1);
   mu_check(strcmp(prevLine, "abc") == 0);
 }
 
@@ -52,9 +52,9 @@ MU_TEST(insert_prev_line) {
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 
-  char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
   printf("LINE: %s\n", line);
 
@@ -67,9 +67,9 @@ MU_TEST(insert_next_line) {
   vimInput("b");
   vimInput("c");
 
-  mu_check(vimWindowGetCursorLine() == 2);
+  mu_check(vimCursorGetLine() == 2);
 
-  char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
   printf("LINE: %s\n", line);
 
@@ -80,7 +80,7 @@ MU_TEST(insert_end) {
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  char_u *line = vimBufferGetLine(curbuf, vimWindowGetCursorLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
   printf("LINE: %s\n", line);
 

--- a/src/apitest/motion_word.c
+++ b/src/apitest/motion_word.c
@@ -10,57 +10,57 @@ void test_setup(void) {
 void test_teardown(void) {}
 
 MU_TEST(test_w) {
-  mu_check(vimWindowGetCursorColumn() == 0);
+  mu_check(vimCursorGetColumn() == 0);
 
   vimInput("w");
 
-  mu_check(vimWindowGetCursorColumn() == 5);
+  mu_check(vimCursorGetColumn() == 5);
 
   vimInput("2");
   vimInput("w");
 
-  mu_check(vimWindowGetCursorColumn() == 12);
+  mu_check(vimCursorGetColumn() == 12);
 
   vimInput("1");
   vimInput("0");
   vimInput("w");
 
-  mu_check(vimWindowGetCursorLine() == 2);
-  mu_check(vimWindowGetCursorColumn() == 19);
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 19);
 }
 
 MU_TEST(test_e) {
-  mu_check(vimWindowGetCursorColumn() == 0);
+  mu_check(vimCursorGetColumn() == 0);
 
   vimInput("e");
 
-  mu_check(vimWindowGetCursorColumn() == 3);
+  mu_check(vimCursorGetColumn() == 3);
 
   vimInput("2");
   vimInput("e");
 
-  mu_check(vimWindowGetCursorColumn() == 10);
+  mu_check(vimCursorGetColumn() == 10);
 
   vimInput("1");
   vimInput("0");
   vimInput("0");
   vimInput("e");
 
-  mu_check(vimWindowGetCursorLine() == 3);
-  mu_check(vimWindowGetCursorColumn() == 36);
+  mu_check(vimCursorGetLine() == 3);
+  mu_check(vimCursorGetColumn() == 36);
 }
 
 MU_TEST(test_b) {
-  mu_check(vimWindowGetCursorColumn() == 0);
+  mu_check(vimCursorGetColumn() == 0);
 
   vimInput("$");
 
   vimInput("b");
-  mu_check(vimWindowGetCursorColumn() == 33);
+  mu_check(vimCursorGetColumn() == 33);
 
   vimInput("5");
   vimInput("b");
-  mu_check(vimWindowGetCursorColumn() == 12);
+  mu_check(vimCursorGetColumn() == 12);
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/src/apitest/normal_mode_motion.c
+++ b/src/apitest/normal_mode_motion.c
@@ -11,42 +11,42 @@ void test_teardown(void) {
 }
 
 MU_TEST(test_G_gg) {
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 
   vimInput("G");
 
-  mu_check(vimWindowGetCursorLine() == 3);
+  mu_check(vimCursorGetLine() == 3);
 
   vimInput("g");
   vimInput("g");
 
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 }
 
 MU_TEST(test_j_k) {
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 
   vimInput("j");
 
-  mu_check(vimWindowGetCursorLine() == 2);
+  mu_check(vimCursorGetLine() == 2);
 
   vimInput("k");
 
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 }
 
 MU_TEST(test_2j_2k) {
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 
   vimInput("2");
   vimInput("j");
 
-  mu_check(vimWindowGetCursorLine() == 3);
+  mu_check(vimCursorGetLine() == 3);
 
   vimInput("2");
   vimInput("k");
 
-  mu_check(vimWindowGetCursorLine() == 1);
+  mu_check(vimCursorGetLine() == 1);
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -54,9 +54,9 @@ void vimSetBufferUpdateCallback(BufferUpdateCallback f) {
   bufferUpdateCallback = f;
 }
 
-linenr_T vimWindowGetCursorLine(void) { return curwin->w_cursor.lnum; };
-colnr_T vimWindowGetCursorColumn(void) { return curwin->w_cursor.col; };
-pos_T vimWindowGetCursorPosition(void) { return curwin->w_cursor; };
+linenr_T vimCursorGetLine(void) { return curwin->w_cursor.lnum; };
+colnr_T vimCursorGetColumn(void) { return curwin->w_cursor.col; };
+pos_T vimCursorGetPosition(void) { return curwin->w_cursor; };
 
 void vimInput(char_u *input) {
   char_u *ptr = NULL;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -35,11 +35,11 @@ int vimBufferGetModified(buf_T *buf);
 void vimSetBufferUpdateCallback(BufferUpdateCallback bufferUpdate);
 
 /***
- * Window Methods
+ * Cursor Methods
  ***/
-linenr_T vimWindowGetCursorLine(void);
-colnr_T vimWindowGetCursorColumn(void);
-pos_T vimWindowGetCursorPosition(void);
+colnr_T vimCursorGetColumn(void);
+linenr_T vimCursorGetLine(void);
+pos_T vimCursorGetPosition(void);
 
 /***
  * User Input
@@ -75,6 +75,5 @@ void vimVisualGetRange(pos_T *startPos, pos_T *endPos);
  ***/
 
 int vimGetMode(void);
-
 
 /* vim: set ft=c : */


### PR DESCRIPTION
In the current plan for `libvim`, it will be up for consumers to manage windows - the abstraction that `libvim` assumes is a single window. Renaming the API to reflect that.