### PR TITLE
Bugfix: Name clash with OCaml symbols

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4021,7 +4021,7 @@ eval5(char_u **arg, typval_T *rettv, int evaluate)
 						   && var2.v_type == VAR_LIST)
 	    {
 		/* concatenate Lists */
-		if (list_concat(rettv->vval.v_list, var2.vval.v_list,
+		if (vim_list_concat(rettv->vval.v_list, var2.vval.v_list,
 							       &var3) == FAIL)
 		{
 		    clear_tv(rettv);

--- a/src/list.c
+++ b/src/list.c
@@ -629,7 +629,7 @@ list_extend(list_T *l1, list_T *l2, listitem_T *bef)
  * Return FAIL when out of memory.
  */
     int
-list_concat(list_T *l1, list_T *l2, typval_T *tv)
+vim_list_concat(list_T *l1, list_T *l2, typval_T *tv)
 {
     list_T	*l;
 

--- a/src/proto/list.pro
+++ b/src/proto/list.pro
@@ -29,7 +29,10 @@ int list_append_number(list_T *l, varnumber_T n);
 int list_insert_tv(list_T *l, typval_T *tv, listitem_T *item);
 void list_insert(list_T *l, listitem_T *ni, listitem_T *item);
 int list_extend(list_T *l1, list_T *l2, listitem_T *bef);
-int list_concat(list_T *l1, list_T *l2, typval_T *tv);
+
+/* Renamed from list_concat -> vim_list_concat due to clash with OCaml namespace */
+int vim_list_concat(list_T *l1, list_T *l2, typval_T *tv);
+
 list_T *list_copy(list_T *orig, int deep, int copyID);
 void vimlist_remove(list_T *l, listitem_T *item, listitem_T *item2);
 char_u *list2string(typval_T *tv, int copyID, int restore_copyID);


### PR DESCRIPTION
Unfortunately the `list_concat` symbol conflicts with a symbol present in the OCaml runtime libraries. It was easier to fix it here.