### PR TITLE
Bugfix: Visual mode not reported correctly with `vimGetMode`

### DIFF
--- a/src/apitest/basic_test.c
+++ b/src/apitest/basic_test.c
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
   win_setheight(100);
 
   buf_T *buf = vimBufferOpen("testfile.txt", 1, 0);
-  assert(vimGetMode() & NORMAL == NORMAL);
+  assert((vimGetMode() & NORMAL) == NORMAL);
 
   char *line = vimBufferGetLine(buf, 1);
   printf("LINE: %s\n", line);
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   assert(vimCursorGetLine() > 1);
 
   vimInput("v");
-  assert(vimGetMode() & VISUAL == VISUAL);
+  assert((vimGetMode() & VISUAL) == VISUAL);
   vimInput("l");
   vimInput("l");
   vimInput("x");

--- a/src/apitest/viminit_no_args.c
+++ b/src/apitest/viminit_no_args.c
@@ -4,5 +4,9 @@ int main(int argc, char **argv) {
   /* Simple test to validate we can run with no args */
   char *c[0];
   vimInit(0, c);
+
+
+  printf("TEST: %d\n", curbuf);
+
   printf("Initialized without crashing\n");
 }

--- a/src/apitest/visual_mode.c
+++ b/src/apitest/visual_mode.c
@@ -18,20 +18,25 @@ MU_TEST(test_visual_is_active) {
   vimInput("v");
   mu_check(vimVisualGetType() == 'v');
   mu_check(vimVisualIsActive() == 1);
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
 
   vimInput("<esc>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
   mu_check(vimVisualIsActive() == 0);
 
   vimInput("<c-v>");
   mu_check(vimVisualGetType() == Ctrl_V);
   mu_check(vimVisualIsActive() == 1);
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
 
   vimInput("<esc>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
   mu_check(vimVisualIsActive() == 0);
 
   vimInput("V");
   mu_check(vimVisualGetType() == 'V');
   mu_check(vimVisualIsActive() == 1);
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
 }
 
 MU_TEST(test_characterwise_range) {

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -113,7 +113,9 @@ void vimVisualGetRange(pos_T *startPos, pos_T *endPos) {
 
 void vimExecute(char_u *cmd) { do_cmdline_cmd(cmd); }
 
-int vimGetMode(void) { return State; }
+int vimGetMode(void) {
+    return get_real_state();
+}
 
 void vimRegisterGet(int reg_name, int *num_lines, char_u ***lines) {
   get_yank_register_value(reg_name, num_lines, lines);


### PR DESCRIPTION
__Issue:__ `vimGetMode() & VISUAL` doesn't work as expected

__Defect:__ We were using the `State` variable, but that actually doesn't get set to `VISUAL`. Instead, a helper, `get_real_state()` , handles this conversion for us.

__Fix:__ Switch from returning `State` directly to using `get_real_state()`