### PR TITLE
Bugfix: Curswant not being updated

### DIFF
--- a/src/apitest/normal_mode_curswant.c
+++ b/src/apitest/normal_mode_curswant.c
@@ -1,0 +1,123 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void) {
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  // Create buffer like:
+  // abc
+  // ab
+  // a
+  // abcd
+
+  vimExecute("e!");
+
+  vimInput("I");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("<cr>");
+  vimInput("a");
+  vimInput("b");
+  vimInput("<cr>");
+  vimInput("a");
+  vimInput("<cr>");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("d");
+  vimInput("<cr>");
+
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_curswant_column2) {
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move one character right
+  vimInput("l");
+
+  mu_check(vimCursorGetColumn() == 1);
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move two characters down
+  vimInput("j");
+  vimInput("j");
+
+  mu_check(vimCursorGetColumn() == 0);
+  mu_check(vimCursorGetLine() == 3);
+
+  vimInput("j");
+  mu_check(vimCursorGetColumn() == 1);
+  mu_check(vimCursorGetLine() == 4);
+}
+
+MU_TEST(test_curswant_maxcolumn) {
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move all the way to the right
+  vimInput("$");
+
+  mu_check(vimCursorGetColumn() == 2);
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move three characters down
+  vimInput("j");
+  vimInput("j");
+  vimInput("j");
+
+  // Cursor should be all the way to the right
+  mu_check(vimCursorGetColumn() == 3);
+  mu_check(vimCursorGetLine() == 4);
+}
+
+MU_TEST(test_curswant_reset) {
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move all the way to the right...
+  vimInput("$");
+  // And the once to the left...
+  // This should reset curswant
+  vimInput("h");
+
+  mu_check(vimCursorGetColumn() == 1);
+  mu_check(vimCursorGetLine() == 1);
+
+  // Move three characters down
+  vimInput("j");
+  vimInput("j");
+  vimInput("j");
+
+  mu_check(vimCursorGetColumn() == 1);
+  mu_check(vimCursorGetLine() == 4);
+}
+
+MU_TEST_SUITE(test_suite) {
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  /* MU_RUN_TEST(test_curswant_column2); */
+  /* MU_RUN_TEST(test_curswant_maxcolumn); */
+  MU_RUN_TEST(test_curswant_reset);
+}
+
+int main(int argc, char **argv) {
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  buf_T *buf = vimBufferOpen("testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+
+  return minunit_status;
+}

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -66,6 +66,7 @@ void vimSetAutoCommandCallback(AutoCommandCallback f) {
 linenr_T vimCursorGetLine(void) { return curwin->w_cursor.lnum; };
 colnr_T vimCursorGetColumn(void) { return curwin->w_cursor.col; };
 pos_T vimCursorGetPosition(void) { return curwin->w_cursor; };
+colnr_T vimCursorGetDesiredColumn(void) { return curwin->w_curswant; };
 
 void vimInput(char_u *input) {
   char_u *ptr = NULL;
@@ -94,6 +95,8 @@ void vimInput(char_u *input) {
       apply_autocmds(EVENT_CURSORMOVED, NULL, NULL, FALSE, curbuf);
     last_cursormoved = curwin->w_cursor;
   }
+
+  update_curswant();
 }
 
 int vimVisualIsActive(void) { return VIsual_active; }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -51,6 +51,14 @@ linenr_T vimCursorGetLine(void);
 pos_T vimCursorGetPosition(void);
 
 /***
+ * vimCursorGetDesiredColumn
+ *
+ * Get the column that we'd like to be at - used to stay in the same
+ * column for up/down cursor motions.
+ */
+colnr_T vimCursorGetDesiredColumn(void);
+
+/***
  * User Input
  ***/
 void vimInput(char_u *input);


### PR DESCRIPTION
__Issue:__ The `curswant` variable, which specifies the 'desired' column (like when moving up/down between lines of different lengths), wasn't being set.

__Defect:__ This is updated in the `main_loop` function in Vim, which hasn't been ported over completely to `libvim`.

__Fix:__ Bring over the `update_curswant` function in `libvim`'s input loop.