### PR TITLE
Commandline search

### DIFF
--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -34,32 +34,11 @@ void test_teardown(void) {
   cmdLineChangedCount = 0;
 }
 
-/* MU_TEST(test_search_forward_esc) { */
-/*     printf("SERACHING!\n"); */
-/*   vimInput("/"); */
-/*   vimInput("h"); */
-/*   vimInput("<esc>"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   vimInput("n"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   vimInput("n"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   vimInput("n"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   vimInput("n"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   vimInput("n"); */
-/*   printf("CURSOR COL: %d\n", vimCursorGetColumn()); */
-/*   /1* mu_check((vimGetMode() & CMDLINE) == CMDLINE); *1/ */
-/*   vimInput("<esc>"); */
-/*   printf("DONE"); */
-/*   /1* mu_check((vimGetMode() & NORMAL) == NORMAL); *1/ */
-/* } */
-
 MU_TEST(test_cmdline_esc) {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
   vimInput("<esc>");
+  printf("MODE: %d\n", vimGetMode());
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
@@ -67,6 +46,7 @@ MU_TEST(test_cmdline_enter) {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
   vimInput("<cr>");
+  printf("MODE: %d\n", vimGetMode());
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 

--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -6,8 +6,6 @@ static int cmdLineLeaveCount = 0;
 static int cmdLineChangedCount = 0;
 
 void onAutoCommand(event_T command, buf_T *buf) {
-  printf("Autocommand: %d\n", command);
-
   switch (command) {
   case EVENT_CMDLINECHANGED:
     cmdLineChangedCount++;
@@ -115,11 +113,15 @@ MU_TEST(test_cmdline_execute) {
 }
 
 MU_TEST(test_cmdline_substitution) {
+  printf("\n\n--START test_cmdline_substitution--\n\n");
   buf_T *buffer = vimBufferGetCurrent();
   int lc = vimBufferGetLineCount(buffer);
   mu_check(lc == 3);
 
+
+  printf("Entering :\n");
   vimInput(":");
+  printf("Entering s\n");
   vimInput("s");
   vimInput("!");
   vimInput("T");
@@ -131,6 +133,7 @@ MU_TEST(test_cmdline_substitution) {
 
   mu_check(strcmp(vimBufferGetLine(buffer, 1),
                   "Ahis is the first line of a test file") == 0);
+  printf("\n--END test_cmdline_substitution--\n");
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -38,7 +38,6 @@ MU_TEST(test_cmdline_esc) {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
   vimInput("<esc>");
-  printf("MODE: %d\n", vimGetMode());
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
@@ -46,7 +45,6 @@ MU_TEST(test_cmdline_enter) {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
   vimInput("<cr>");
-  printf("MODE: %d\n", vimGetMode());
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
@@ -93,15 +91,12 @@ MU_TEST(test_cmdline_execute) {
 }
 
 MU_TEST(test_cmdline_substitution) {
-  printf("\n\n--START test_cmdline_substitution--\n\n");
   buf_T *buffer = vimBufferGetCurrent();
   int lc = vimBufferGetLineCount(buffer);
   mu_check(lc == 3);
 
 
-  printf("Entering :\n");
   vimInput(":");
-  printf("Entering s\n");
   vimInput("s");
   vimInput("!");
   vimInput("T");
@@ -113,7 +108,6 @@ MU_TEST(test_cmdline_substitution) {
 
   mu_check(strcmp(vimBufferGetLine(buffer, 1),
                   "Ahis is the first line of a test file") == 0);
-  printf("\n--END test_cmdline_substitution--\n");
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/src/apitest/cmdline_completion.c
+++ b/src/apitest/cmdline_completion.c
@@ -48,6 +48,8 @@ MU_TEST(test_cmdline_get_text) {
   vimInput("<c-h>");
   mu_check(strcmp(vimCommandLineGetText(), "ab") == 0);
   mu_check(vimCommandLineGetPosition() == 2);
+
+  vimInput("<cr>");
 }
 
 MU_TEST(test_cmdline_completions) {

--- a/src/apitest/cmdline_search.c
+++ b/src/apitest/cmdline_search.c
@@ -1,0 +1,79 @@
+#include "libvim.h"
+#include "minunit.h"
+
+static int cmdLineEnterCount = 0;
+static int cmdLineLeaveCount = 0;
+static int cmdLineChangedCount = 0;
+
+void test_setup(void) {
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_search_forward_esc) {
+  vimInput("/");
+  vimInput("s");
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 4);
+  mu_check(strcmp(vimSearchGetPattern(), "s") == 0);
+
+  vimInput("t");
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 17);
+  mu_check(strcmp(vimSearchGetPattern(), "st") == 0);
+  vimInput("<cr>");
+
+  // Note - while in `incsearch`, the positions
+  // returned match the END of the match.
+  // That's why there is a difference in the column when pressing <CR>
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 15);
+
+  vimInput("n");
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 30);
+
+  vimInput("n");
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 31);
+
+  vimInput("n");
+  mu_check(vimCursorGetLine() == 3);
+  mu_check(vimCursorGetColumn() == 30);
+
+  vimInput("N");
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 31);
+
+  vimInput("N");
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 30);
+
+  mu_check(strcmp(vimSearchGetPattern(), "st") == 0);
+}
+
+MU_TEST_SUITE(test_suite) {
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_search_forward_esc);
+}
+
+int main(int argc, char **argv) {
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  buf_T *buf = vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/minunit.h
+++ b/src/apitest/minunit.h
@@ -104,23 +104,28 @@ static void (*minunit_teardown)(void) = NULL;
 	minunit_teardown = teardown_fun;\
 )
 
+#define STR(X) #X
+#define ASSTR(X) STR(X)
+
 /*  Test runner */
 #define MU_RUN_TEST(test) MU__SAFE_BLOCK(\
 	if (minunit_real_timer==0 && minunit_proc_timer==0) {\
 		minunit_real_timer = mu_timer_real();\
 		minunit_proc_timer = mu_timer_cpu();\
 	}\
+  printf("\n-- START " ASSTR(test) " --\n"); \
 	if (minunit_setup) (*minunit_setup)();\
 	minunit_status = 0;\
 	test();\
 	minunit_run++;\
 	if (minunit_status) {\
 		minunit_fail++;\
-		printf("F");\
+		printf("[FAILED]");\
 		printf("\n%s\n", minunit_last_message);\
 	}\
 	fflush(stdout);\
 	if (minunit_teardown) (*minunit_teardown)();\
+  printf("\n-- END " ASSTR(test) " --\n"); \
 )
 
 /*  Report */
@@ -147,7 +152,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(".");\
+		printf(".\n");\
 	}\
 )
 
@@ -165,7 +170,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_status = 1;\
 		return;\
 	} else {\
-		printf(".");\
+		printf(".\n");\
 	}\
 )
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2762,7 +2762,7 @@ theend:
 
 executionStatus_T state_cmdline_execute(void *ctx, int c) {
     cmdlineState_T *context = (cmdlineState_T *)ctx;
-    
+
     if (context->bail_immediately == TRUE) {
 	    return COMPLETED_UNHANDLED;
     }
@@ -3913,8 +3913,12 @@ executionStatus_T state_cmdline_execute(void *ctx, int c) {
 	goto cmdline_changed;
 
 returncmd:
-	do_cmdline_cmd(ccline.cmdbuff);
-	return COMPLETED;
+	if (context->firstc == ':') {
+	    do_cmdline_cmd(ccline.cmdbuff);
+	    return COMPLETED_UNHANDLED;
+	} else {
+    return COMPLETED_UNHANDLED;
+	}
 
 /*
  * This part implements incremental searches for "/" and "?"
@@ -3938,13 +3942,6 @@ cmdline_changed:
     char_u	**files_found;
 
 	set_expand_context(&context->xpc);
-	/* int i = expand_cmdline(&context->xpc, ccline.cmdbuff, ccline.cmdpos, */
-	/* 					    &num_files, &files_found); */
-	/* TODO: Factor this to a method */
-	/* printf ("COMPLETEIONS: %d\n", num_files); */
-	/* for(int x = 0; x < num_files; x++) { */
-	/*     printf( "-- %d : %s\n", x, files_found[x]); */
-	/* } */
 
 #ifdef FEAT_SEARCH_EXTRA
 	may_do_incsearch_highlighting(context->firstc, context->count, &context->is_state);
@@ -3957,7 +3954,6 @@ cmdline_changed:
 # endif
 		)
 #endif
-
     return HANDLED;
 }
 
@@ -3967,7 +3963,7 @@ void state_cmdline_cleanup(void *ctx) {
     /* Trigger CmdlineLeave autocommands. */
     trigger_cmd_autocmd(context->cmdline_type, EVENT_CMDLINELEAVE);
 
-	  ccline.cmdbuff = NULL;
+	  /* ccline.cmdbuff = NULL; */
     State = context->save_State;
     vim_free(context);
 }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -3965,7 +3965,6 @@ void state_cmdline_cleanup(void *ctx) {
 
 	  /* ccline.cmdbuff = NULL; */
     State = context->save_State;
-    printf("STATE AFTER CMDLINE CLEANUP: %d\n", State);
     vim_free(context);
 }
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -3965,6 +3965,7 @@ void state_cmdline_cleanup(void *ctx) {
 
 	  /* ccline.cmdbuff = NULL; */
     State = context->save_State;
+    printf("STATE AFTER CMDLINE CLEANUP: %d\n", State);
     vim_free(context);
 }
 

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -133,6 +133,8 @@ void vimVisualGetRange(pos_T *startPos, pos_T *endPos) {
 
 pos_T *vimSearchGetMatchingPair(int initc) { return findmatch(NULL, initc); }
 
+char_u *vimSearchGetPattern() { return get_search_pat(); }
+
 void vimExecute(char_u *cmd) { do_cmdline_cmd(cmd); }
 
 int vimGetMode(void) { return get_real_state(); }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -48,9 +48,9 @@ void vimSetAutoCommandCallback(AutoCommandCallback autoCommandDispatch);
  ***/
 
 char_u vimCommandLineGetType(void);
-char_u* vimCommandLineGetText(void);
+char_u *vimCommandLineGetText(void);
 int vimCommandLineGetPosition(void);
-void vimCommandLineGetCompletions(char ***completions, int* count);
+void vimCommandLineGetCompletions(char ***completions, int *count);
 
 /***
  * Cursor Methods
@@ -109,6 +109,13 @@ void vimVisualGetRange(pos_T *startPos, pos_T *endPos);
  * result is NULL if no match found.
  */
 pos_T *vimSearchGetMatchingPair(int initc);
+
+/*
+ * vimSearchGetPattern
+ *
+ * Get the current search pattern
+ */
+char_u *vimSearchGetPattern();
 
 /***
  * Misc

--- a/src/normal.c
+++ b/src/normal.c
@@ -610,7 +610,7 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c) {
 				    if (cmd == NULL) {
 						    clearop(context->oap);
 				    } else {
-					    cap->searchbuf = cmd;
+					    context->ca.searchbuf = cmd;
 					    /* Seed the search - bump it forward and back so everything is set for N and n */
 			      (void)normal_search(&context->ca, cmdc, cmd, 0);
 			      (void)normal_search(&context->ca, cmdc, NULL, SEARCH_REV | SEARCH_END);
@@ -5573,7 +5573,6 @@ static void nv_next(cmdarg_T *cap) {
     /* Avoid getting stuck on the current cursor position, which can
      * happen when an offset is given and the cursor is on the last char
      * in the buffer: Repeat with count + 1. */
-    printf("Trying search again?\n");
     cap->count1 += 1;
     (void)normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg);
     cap->count1 -= 1;

--- a/src/normal.c
+++ b/src/normal.c
@@ -610,6 +610,7 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c) {
 				    if (cmd == NULL) {
 						    clearop(context->oap);
 				    } else {
+					    cap->searchbuf = cmd;
 					    /* Seed the search - bump it forward and back so everything is set for N and n */
 			      (void)normal_search(&context->ca, cmdc, cmd, 0);
 			      (void)normal_search(&context->ca, cmdc, NULL, SEARCH_REV | SEARCH_END);
@@ -5548,7 +5549,6 @@ static void nv_dollar(cmdarg_T *cap) {
  */
 static void nv_search(cmdarg_T *cap) {
   oparg_T *oap = cap->oap;
-  pos_T save_cursor = curwin->w_cursor;
 
   if (cap->cmdchar == '?' && cap->oap->op_type == OP_ROT13) {
     /* Translate "g??" to "g?g?" */
@@ -5558,25 +5558,7 @@ static void nv_search(cmdarg_T *cap) {
     return;
   }
 
-  /* When using 'incsearch' the cursor may be moved to set a different search
-   * start position. */
-
-  // TODO: How to handle this?
-  /* cap->searchbuf = getcmdline(cap->cmdchar, cap->count1, 0); */
-  printf("PUSHING CMDLINE state: %c\n", cap->cmdchar);
   sm_push_cmdline(cap->cmdchar, cap->count1, 0);
-
-  /* TODO: Port over to return? */
-
-  /* if (cap->searchbuf == NULL) { */
-  /*   clearop(oap); */
-  /*   return; */
-  /* } */
-
-  /* (void)normal_search(cap, cap->cmdchar, cap->searchbuf, */
-  /*                     (cap->arg || !EQUAL_POS(save_cursor, curwin->w_cursor)) */
-  /*                         ? 0 */
-  /*                         : SEARCH_MARK); */
 }
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -567,7 +567,6 @@ void start_normal_mode(normalCmd_T *context) {
   /* Set v:count here, when called from main() and not a stuffed
    * command, so that v:count can be used in an expression mapping
    * when there is no count. Do set it for redo. */
-					printf("Searching in reverse! CURRENT LINE %d and COLUMN %d\n", curwin->w_cursor.lnum, curwin->w_cursor.col);
   if (readbuf1_empty())
     set_vcount_ca(&ca, &context->set_prevcount);
 #endif
@@ -595,8 +594,6 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c) {
   LANGMAP_ADJUST(c, get_real_state() != SELECTMODE);
   normalCmd_T *context = (normalCmd_T *)ctx;
 
-  printf("state_normal_cmd_execute\n");
-
   if (context->returnState != NORMAL) {
       
       switch (context->returnState) {
@@ -609,35 +606,23 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c) {
 		      // hasn't been executed yet.
 			    char_u *cmd = ccline.cmdbuff;
 			    char_u cmdc = ccline.cmdfirstc;
-		      printf("RETURNING FROM CMDLINE MODE! Type: %c cmd: %s\n", cmdc, cmd);
 			    if (cmdc == '/' || cmdc == '?') {
 				    if (cmd == NULL) {
 						    clearop(context->oap);
 				    } else {
 					    /* Seed the search - bump it forward and back so everything is set for N and n */
-					printf("N - LINE: %d COLUMN: %d\n", curwin->w_cursor.lnum, curwin->w_cursor.col);
 			      (void)normal_search(&context->ca, cmdc, cmd, 0);
-					printf("N - LINE: %d COLUMN: %d\n", curwin->w_cursor.lnum, curwin->w_cursor.col);
 			      (void)normal_search(&context->ca, cmdc, NULL, SEARCH_REV | SEARCH_END);
-					printf("N - LINE: %d COLUMN: %d\n", curwin->w_cursor.lnum, curwin->w_cursor.col);
+
+			      /* TODO: SEARCH_MARK parameter - how do we wire that up? We may need to stash save_cursor somewhere. */
+				      /* (void)normal_search(cap, cap->cmdchar, cap->searchbuf, */
+				      /*                     (cap->arg || !EQUAL_POS(save_cursor, curwin->w_cursor)) */
+				      /*                         ? 0 */
+				      /*                         : SEARCH_MARK); */
 				    }
+			    }
 			    start_normal_mode(context);
 			    return HANDLED;
-					
-  /* if (cap->searchbuf == NULL) { */
-  /*   clearop(oap); */
-  /*   return; */
-  /* } */
-
-  /* (void)normal_search(cap, cap->cmdchar, cap->searchbuf, */
-  /*                     (cap->arg || !EQUAL_POS(save_cursor, curwin->w_cursor)) */
-  /*                         ? 0 */
-  /*                         : SEARCH_MARK); */
-				  
-				    /* printf("do_cmdline_cmd: %s\n", cmd); */
-				    /* do_cmdline_cmd(cmd); */
-				    /* abandon_cmdline(); */
-			    }
 			    break;
 			  default:
 			    break;
@@ -814,7 +799,6 @@ restart_state:
 
     int stateMode = sm_get_current_mode();
     if (stateMode != NORMAL) {
-		  printf("-- Setting context->returnState: %d\n", stateMode);
 	    context->returnState = stateMode;
 	    return HANDLED;
     }

--- a/src/option.c
+++ b/src/option.c
@@ -1506,7 +1506,7 @@ static struct vimoption options[] =
 			    SCTX_INIT},
     {"incsearch",   "is",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_is, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
 #if defined(FEAT_CINDENT) && defined(FEAT_EVAL)
 			    (char_u *)&p_inde, PV_INDE,


### PR DESCRIPTION
Prior to this change, when moving to the command line search functionality, via either `/` or `?`, the input would be blocked. This refactors the search functionality to map to our state machine - when `/` or `?` are received in the normal mode state, we switches to the command line state, and then do some processing on the result when returning.