### PR TITLE
Bugfix - Commandline is slow when searching

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4580,38 +4580,13 @@ redrawcmdline(void)
 redrawcmdline_ex(int do_compute_cmdrow)
 {
     // libvim - noop
-    
-    /* if (cmd_silent) */
-	/* return; */
-    /* need_wait_return = FALSE; */
-    /* if (do_compute_cmdrow) */
-	/* compute_cmdrow(); */
-    /* redrawcmd(); */
-    /* cursorcmd(); */
 }
 
     static void
 redrawcmdprompt(void)
 {
     // libvim - noop
-    /* int		i; */
-
-    /* if (cmd_silent) */
-	/* return; */
-    /* if (ccline.cmdfirstc != NUL) */
-	/* msg_putchar(ccline.cmdfirstc); */
-    /* if (ccline.cmdprompt != NULL) */
-    /* { */
-	/* msg_puts_attr((char *)ccline.cmdprompt, ccline.cmdattr); */
-	/* ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns; */
-	/* /1* do the reverse of set_cmdspos() *1/ */
-	/* if (ccline.cmdfirstc != NUL) */
-	    /* --ccline.cmdindent; */
-    /* } */
-    /* else */
-	/* for (i = ccline.cmdindent; i > 0; --i) */
-	    /* msg_putchar(' '); */
-/* } */
+}
 
 /*
  * Redraw what is currently on the command line.
@@ -4620,40 +4595,6 @@ redrawcmdprompt(void)
 redrawcmd(void)
 {
     // libvim - noop
-
-    /*if (cmd_silent)*/
-	/*return;*/
-
-    /* when 'incsearch' is set there may be no command line while redrawing */
-    /*if (ccline.cmdbuff == NULL)*/
-    /*{*/
-	/*windgoto(cmdline_row, 0);*/
-	/*msg_clr_eos();*/
-	/*return;*/
-    /*}*/
-
-    /*msg_start();*/
-    /*redrawcmdprompt();*/
-
-    /* Don't use more prompt, truncate the cmdline if it doesn't fit. */
-    /*msg_no_more = TRUE;*/
-    /*draw_cmdline(0, ccline.cmdlen);*/
-    /*msg_clr_eos();*/
-    /*msg_no_more = FALSE;*/
-
-    /*set_cmdspos_cursor();*/
-    /*if (extra_char != NUL)*/
-	/*putcmdline(extra_char, extra_char_shift);*/
-
-    /*
-    / An emsg() before may have set msg_scroll. This is used in normal mode,*/
-    /* in cmdline mode we can reset them now.*/
-    /* */
-    /*msg_scroll = FALSE;		 next message overwrites cmdline */
-
-    /* Typing ':' at the more prompt may set skip_redraw.  We don't want this*/
-    /* in cmdline mode */
-    /*skip_redraw = FALSE;*/
 }
 
     void

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4624,7 +4624,7 @@ redrawcmd(void)
     /*if (cmd_silent)*/
 	/*return;*/
 
-    /*/* when 'incsearch' is set there may be no command line while redrawing */*/
+    /* when 'incsearch' is set there may be no command line while redrawing */
     /*if (ccline.cmdbuff == NULL)*/
     /*{*/
 	/*windgoto(cmdline_row, 0);*/
@@ -4635,7 +4635,7 @@ redrawcmd(void)
     /*msg_start();*/
     /*redrawcmdprompt();*/
 
-    /*/* Don't use more prompt, truncate the cmdline if it doesn't fit. */*/
+    /* Don't use more prompt, truncate the cmdline if it doesn't fit. */
     /*msg_no_more = TRUE;*/
     /*draw_cmdline(0, ccline.cmdlen);*/
     /*msg_clr_eos();*/
@@ -4645,14 +4645,14 @@ redrawcmd(void)
     /*if (extra_char != NUL)*/
 	/*putcmdline(extra_char, extra_char_shift);*/
 
-    /*/**/
-    /* * An emsg() before may have set msg_scroll. This is used in normal mode,*/
-    /* * in cmdline mode we can reset them now.*/
-    /* */*/
-    /*msg_scroll = FALSE;		/* next message overwrites cmdline */*/
+    /*
+    / An emsg() before may have set msg_scroll. This is used in normal mode,*/
+    /* in cmdline mode we can reset them now.*/
+    /* */
+    /*msg_scroll = FALSE;		 next message overwrites cmdline */
 
-    /*/* Typing ':' at the more prompt may set skip_redraw.  We don't want this*/
-    /* * in cmdline mode */*/
+    /* Typing ':' at the more prompt may set skip_redraw.  We don't want this*/
+    /* in cmdline mode */
     /*skip_redraw = FALSE;*/
 }
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -556,8 +556,8 @@ may_do_incsearch_highlighting(
     else if (found != 0)
 	curwin->w_cursor = end_pos;
 
-    msg_starthere();
-    redrawcmdline();
+    // libvim - redrawing is not necessary
+    // redrawcmdline();
     is_state->did_incsearch = TRUE;
 }
 
@@ -3650,9 +3650,6 @@ cmdline_changed:
 	/* Trigger CmdlineChanged autocommands. */
 	trigger_cmd_autocmd(context->cmdline_type, EVENT_CMDLINECHANGED);
 
-    int		num_files;
-    char_u	**files_found;
-
 	set_expand_context(&context->xpc);
 
 #ifdef FEAT_SEARCH_EXTRA
@@ -4582,36 +4579,39 @@ redrawcmdline(void)
     void
 redrawcmdline_ex(int do_compute_cmdrow)
 {
-    if (cmd_silent)
-	return;
-    need_wait_return = FALSE;
-    if (do_compute_cmdrow)
-	compute_cmdrow();
-    redrawcmd();
-    cursorcmd();
+    // libvim - noop
+    
+    /* if (cmd_silent) */
+	/* return; */
+    /* need_wait_return = FALSE; */
+    /* if (do_compute_cmdrow) */
+	/* compute_cmdrow(); */
+    /* redrawcmd(); */
+    /* cursorcmd(); */
 }
 
     static void
 redrawcmdprompt(void)
 {
-    int		i;
+    // libvim - noop
+    /* int		i; */
 
-    if (cmd_silent)
-	return;
-    if (ccline.cmdfirstc != NUL)
-	msg_putchar(ccline.cmdfirstc);
-    if (ccline.cmdprompt != NULL)
-    {
-	msg_puts_attr((char *)ccline.cmdprompt, ccline.cmdattr);
-	ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns;
-	/* do the reverse of set_cmdspos() */
-	if (ccline.cmdfirstc != NUL)
-	    --ccline.cmdindent;
-    }
-    else
-	for (i = ccline.cmdindent; i > 0; --i)
-	    msg_putchar(' ');
-}
+    /* if (cmd_silent) */
+	/* return; */
+    /* if (ccline.cmdfirstc != NUL) */
+	/* msg_putchar(ccline.cmdfirstc); */
+    /* if (ccline.cmdprompt != NULL) */
+    /* { */
+	/* msg_puts_attr((char *)ccline.cmdprompt, ccline.cmdattr); */
+	/* ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns; */
+	/* /1* do the reverse of set_cmdspos() *1/ */
+	/* if (ccline.cmdfirstc != NUL) */
+	    /* --ccline.cmdindent; */
+    /* } */
+    /* else */
+	/* for (i = ccline.cmdindent; i > 0; --i) */
+	    /* msg_putchar(' '); */
+/* } */
 
 /*
  * Redraw what is currently on the command line.
@@ -4619,39 +4619,41 @@ redrawcmdprompt(void)
     void
 redrawcmd(void)
 {
-    if (cmd_silent)
-	return;
+    // libvim - noop
 
-    /* when 'incsearch' is set there may be no command line while redrawing */
-    if (ccline.cmdbuff == NULL)
-    {
-	windgoto(cmdline_row, 0);
-	msg_clr_eos();
-	return;
-    }
+    /*if (cmd_silent)*/
+	/*return;*/
 
-    msg_start();
-    redrawcmdprompt();
+    /*/* when 'incsearch' is set there may be no command line while redrawing */*/
+    /*if (ccline.cmdbuff == NULL)*/
+    /*{*/
+	/*windgoto(cmdline_row, 0);*/
+	/*msg_clr_eos();*/
+	/*return;*/
+    /*}*/
 
-    /* Don't use more prompt, truncate the cmdline if it doesn't fit. */
-    msg_no_more = TRUE;
-    draw_cmdline(0, ccline.cmdlen);
-    msg_clr_eos();
-    msg_no_more = FALSE;
+    /*msg_start();*/
+    /*redrawcmdprompt();*/
 
-    set_cmdspos_cursor();
-    if (extra_char != NUL)
-	putcmdline(extra_char, extra_char_shift);
+    /*/* Don't use more prompt, truncate the cmdline if it doesn't fit. */*/
+    /*msg_no_more = TRUE;*/
+    /*draw_cmdline(0, ccline.cmdlen);*/
+    /*msg_clr_eos();*/
+    /*msg_no_more = FALSE;*/
 
-    /*
-     * An emsg() before may have set msg_scroll. This is used in normal mode,
-     * in cmdline mode we can reset them now.
-     */
-    msg_scroll = FALSE;		/* next message overwrites cmdline */
+    /*set_cmdspos_cursor();*/
+    /*if (extra_char != NUL)*/
+	/*putcmdline(extra_char, extra_char_shift);*/
 
-    /* Typing ':' at the more prompt may set skip_redraw.  We don't want this
-     * in cmdline mode */
-    skip_redraw = FALSE;
+    /*/**/
+    /* * An emsg() before may have set msg_scroll. This is used in normal mode,*/
+    /* * in cmdline mode we can reset them now.*/
+    /* */*/
+    /*msg_scroll = FALSE;		/* next message overwrites cmdline */*/
+
+    /*/* Typing ':' at the more prompt may set skip_redraw.  We don't want this*/
+    /* * in cmdline mode */*/
+    /*skip_redraw = FALSE;*/
 }
 
     void


### PR DESCRIPTION
__Issue:__ When running a `/` command, and typing, the responsiveness is much slower than expected.

__Defect:__ We are flushing a lot of data to the message buffer, but not using it. There seems to be another contributing factor - the `cmdindent` value causing a lot of ' ' space characters to be flushed when rendering - but this entire redrawing of the command line is not necessary for `libvim`, as it is the responsibility of the `libvim` consumer to render the command line. Essentially, the command redraw was spamming indefinitely and getting killed by a timer.

__Fix:__ Disable the redrawing of the command line for now. In a future change, we'll do more cleanup across this and the core `message.c` to externalize messages and reduce the amount of terminal rendering the library needs to consider.