### PR TITLE
Bugfix: Change operator hangs

### DIFF
--- a/src/apitest/change_operator.c
+++ b/src/apitest/change_operator.c
@@ -19,7 +19,8 @@ MU_TEST(test_change_word) {
   vimInput("c");
   vimInput("<esc>");
 
-  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc is the first line of a test file") == 0);
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1),
+                  "abc is the first line of a test file") == 0);
 }
 
 MU_TEST(test_change_line_C) {

--- a/src/apitest/change_operator.c
+++ b/src/apitest/change_operator.c
@@ -2,6 +2,9 @@
 #include "minunit.h"
 
 void test_setup(void) {
+  vimInput("<esc>");
+  vimInput("<esc>");
+
   vimExecute("e!");
 
   vimInput("g");
@@ -17,8 +20,9 @@ MU_TEST(test_change_word) {
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<esc>");
+  vimInput("<c-c>");
 
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1),
                   "abc is the first line of a test file") == 0);
 }
@@ -28,8 +32,9 @@ MU_TEST(test_change_line_C) {
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<esc>");
+  vimInput("<c-c>");
 
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
 }
 
@@ -39,8 +44,9 @@ MU_TEST(test_change_line_c$) {
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<esc>");
+  vimInput("<c-c>");
 
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
 }
 

--- a/src/apitest/change_operator.c
+++ b/src/apitest/change_operator.c
@@ -1,0 +1,65 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void) {
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_change_word) {
+  vimInput("c");
+  vimInput("w");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("<esc>");
+
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc is the first line of a test file") == 0);
+}
+
+MU_TEST(test_change_line_C) {
+  vimInput("C");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("<esc>");
+
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
+}
+
+MU_TEST(test_change_line_c$) {
+  vimInput("c");
+  vimInput("$");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("<esc>");
+
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
+}
+
+MU_TEST_SUITE(test_suite) {
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_change_word);
+  MU_RUN_TEST(test_change_line_C);
+  MU_RUN_TEST(test_change_line_c$);
+}
+
+int main(int argc, char **argv) {
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  buf_T *buf = vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/change_operator.c
+++ b/src/apitest/change_operator.c
@@ -50,12 +50,50 @@ MU_TEST(test_change_line_c$) {
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
 }
 
+MU_TEST(test_change_redo) {
+  vimInput("c");
+  vimInput("w");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput("<c-c>");
+  vimInput("j");
+  vimInput("_");
+  vimInput(".");
+
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 2));
+  mu_check(strcmp(vimBufferGetLine(curbuf, 2), "abc is the second line of a test file") == 0);
+}
+
+MU_TEST(test_change_macro) {
+  vimInput("q");
+  vimInput("a");
+
+  vimInput("0");
+  vimInput("C");
+  vimInput("1");
+  vimInput("2");
+  vimInput("3");
+  vimInput("<c-c>");
+  vimInput("q");
+
+
+  vimInput("j");
+  vimInput("@");
+  vimInput("a");
+
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 2));
+  mu_check(strcmp(vimBufferGetLine(curbuf, 2), "123") == 0);
+}
+
 MU_TEST_SUITE(test_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_change_word);
   MU_RUN_TEST(test_change_line_C);
   MU_RUN_TEST(test_change_line_c$);
+  MU_RUN_TEST(test_change_redo);
+  MU_RUN_TEST(test_change_macro);
 }
 
 int main(int argc, char **argv) {

--- a/src/normal.c
+++ b/src/normal.c
@@ -1951,19 +1951,19 @@ void do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank) {
 #endif
         /* Reset finish_op now, don't want it set inside edit(). */
         finish_op = FALSE;
+
+        // TODO: Libvim?
         /* if (op_change(oap)) /1* will call edit() *1/ */
         /*   cap->retval |= CA_COMMAND_BUSY; */
 
+        sm_push_change(oap);
+        restart_edit = 0;
 
-	      sm_push_change(oap);
-	      restart_edit = 0;
-
-	      /* TODO: Set this on return? */
+        // TODO: Libvim?
+        /* TODO: Set this on return? */
         /* if (restart_edit == 0) */
         /*   restart_edit = restart_edit_save; */
-	      /* sm_push_insert(cap->cmdchar, 1, 1); */
-
-	      return;
+        return;
 
       }
       break;

--- a/src/proto/ops.pro
+++ b/src/proto/ops.pro
@@ -1,4 +1,8 @@
 /* ops.c */
+void *state_change_initialize(oparg_T *oap);
+executionStatus_T state_change_execute(void *ctx, int c);
+void state_change_cleanup(void *ctx);
+
 int get_op_type(int char1, int char2);
 int op_on_lines(int op);
 int op_is_change(int op);
@@ -31,7 +35,6 @@ int op_replace(oparg_T *oap, int c);
 void op_tilde(oparg_T *oap);
 int swapchar(int op_type, pos_T *pos);
 void op_insert(oparg_T *oap, long count1);
-int op_change(oparg_T *oap);
 void init_yank(void);
 void clear_registers(void);
 int op_yank(oparg_T *oap, int deleting, int mess);

--- a/src/proto/state_machine.pro
+++ b/src/proto/state_machine.pro
@@ -4,6 +4,7 @@ void sm_push(int mode, void *context, state_execute executeFn, state_cleanup cle
 
 void sm_push_insert(int cmdchar, int startln, long count);
 void sm_push_normal();
+void sm_push_change(oparg_T *oap);
 void sm_push_cmdline(int cmdchar, long count, int indent);
 
 void sm_execute_normal(char_u *keys);

--- a/src/state_machine.c
+++ b/src/state_machine.c
@@ -42,6 +42,10 @@ void sm_push_cmdline(int cmdchar, long count, int indent) {
   sm_push(CMDLINE, state_cmdline_initialize(cmdchar, count, indent), state_cmdline_execute, state_cmdline_cleanup);
 }
 
+void sm_push_change(oparg_T *oap) {
+    sm_push(INSERT, state_change_initialize(oap), state_change_execute, state_change_cleanup);
+}
+
 /*
  * sm_execute_normal
  *


### PR DESCRIPTION
__Issue:__ Any change commands - like `cw`, `c$`, `C` - currently hang.

__Defect:__ The change operator calls `ops_change` which uses the old, blocking API instead of the new state machine.

__Fix:__ Create a change state to encapsulate some of the state implicit around the blocking call in `ops_change`, and use that instead.