### PR TITLE
Bugfix: Visual mode operator

### DIFF
--- a/src/apitest/visual_mode_operator.c
+++ b/src/apitest/visual_mode_operator.c
@@ -25,6 +25,20 @@ MU_TEST(test_visual_linewise_delete) {
   mu_check(strcmp(line, "This is the second line of a test file") == 0);
 }
 
+MU_TEST(test_visual_linewise_motion_delete) {
+  vimInput("V");
+
+  vimInput("2");
+  vimInput("j");
+
+  vimInput("d");
+
+  mu_check(vimBufferGetLineCount(curbuf) == 1);
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "") == 0);
+}
+
 MU_TEST(test_visual_character_delete) {
     vimInput("v");
     vimInput("l");
@@ -39,6 +53,7 @@ MU_TEST_SUITE(test_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_visual_linewise_delete);
+  MU_RUN_TEST(test_visual_linewise_motion_delete);
   MU_RUN_TEST(test_visual_character_delete);
 }
 

--- a/src/apitest/visual_mode_operator.c
+++ b/src/apitest/visual_mode_operator.c
@@ -40,13 +40,13 @@ MU_TEST(test_visual_linewise_motion_delete) {
 }
 
 MU_TEST(test_visual_character_delete) {
-    vimInput("v");
-    vimInput("l");
-    vimInput("d");
+  vimInput("v");
+  vimInput("l");
+  vimInput("d");
 
-    char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-    printf("LINE: %s\n", line);
-    mu_check(strcmp(line, "is is the first line of a test file") == 0);
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "is is the first line of a test file") == 0);
 }
 
 MU_TEST_SUITE(test_suite) {

--- a/src/apitest/visual_mode_operator.c
+++ b/src/apitest/visual_mode_operator.c
@@ -1,0 +1,56 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void) {
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_visual_linewise_delete) {
+  vimInput("V");
+
+  vimInput("d");
+
+  mu_check(vimBufferGetLineCount(curbuf) == 2);
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "This is the second line of a test file") == 0);
+}
+
+MU_TEST(test_visual_character_delete) {
+    vimInput("v");
+    vimInput("l");
+    vimInput("d");
+
+    char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+    printf("LINE: %s\n", line);
+    mu_check(strcmp(line, "is is the first line of a test file") == 0);
+}
+
+MU_TEST_SUITE(test_suite) {
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_visual_linewise_delete);
+  MU_RUN_TEST(test_visual_character_delete);
+}
+
+int main(int argc, char **argv) {
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  buf_T *buf = vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/normal.c
+++ b/src/normal.c
@@ -800,7 +800,7 @@ restart_state:
     /*
      * If an operation is pending, handle it...
      */
-    if (finish_op) {
+    if (finish_op || VIsual_active) {
 	     do_pending_operator(&context->ca, context->old_col, FALSE);
     }
 


### PR DESCRIPTION
__Issue:__ Using an operator like `d` after visual mode didn't work correctly.

__Defect:__ The `do_pending_operator` wasn't being hit in visual mode.

__Fix:__ Run `do_pending_operator` if we are in visual mode.