### PR TITLE
Bugfix: Unpredictable scrolling / topline behavior

### DIFF
--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -31,7 +31,9 @@ MU_TEST(test_set_get_metrics) {
   vimWindowSetWidth(1000);
   vimWindowSetHeight(2000);
 
+
   mu_check(vimWindowGetWidth() == 1000);
+  printf("ACTUAL HEIGHT VALUE: %d\n", vimWindowGetHeight());
   mu_check(vimWindowGetHeight() == 2000);
 }
 

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -28,13 +28,13 @@ MU_TEST(test_set_get_metrics) {
   mu_check(vimWindowGetWidth() == 20);
   mu_check(vimWindowGetHeight() == 21);
 
-  vimWindowSetWidth(1000);
-  vimWindowSetHeight(2000);
+  vimWindowSetWidth(100);
+  printf("-- vimWindowSetHeight START --\n");
+  vimWindowSetHeight(101);
+  printf("-- vimWindowSetHeight END --\n");
 
-
-  mu_check(vimWindowGetWidth() == 1000);
-  printf("ACTUAL HEIGHT VALUE: %d\n", vimWindowGetHeight());
-  mu_check(vimWindowGetHeight() == 2000);
+  mu_check(vimWindowGetWidth() == 100);
+  mu_check(vimWindowGetHeight() == 101);
 }
 
 MU_TEST(test_simple_scroll) {

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -98,6 +98,33 @@ MU_TEST(test_h_m_l) {
   mu_check(vimCursorGetLine() == 50);
 }
 
+MU_TEST(test_only_scroll_at_boundary) {
+
+  vimWindowSetWidth(80);
+  vimWindowSetHeight(63);
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("z");
+  vimInput("t");
+
+  mu_check(vimWindowGetTopLine() == 1);
+
+  // Verify viewport doesn't scroll even when cursor moves down
+  vimInput("6");
+  vimInput("2");
+  vimInput("j");
+  mu_check(vimWindowGetTopLine() == 1);
+
+  // Should scroll now
+  vimInput("j");
+  mu_check(vimWindowGetTopLine() == 2);
+
+  // Shouldn't scroll moving a single line up
+  vimInput("k");
+  mu_check(vimWindowGetTopLine() == 2);
+}
+
 MU_TEST_SUITE(test_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
@@ -105,13 +132,11 @@ MU_TEST_SUITE(test_suite) {
   MU_RUN_TEST(test_simple_scroll);
   MU_RUN_TEST(test_small_screen_scroll);
   MU_RUN_TEST(test_h_m_l);
+  MU_RUN_TEST(test_only_scroll_at_boundary);
 }
 
 int main(int argc, char **argv) {
   vimInit(argc, argv);
-
-  win_setwidth(80);
-  win_setheight(40);
 
   buf_T *buf = vimBufferOpen("collateral/lines_100.txt", 1, 0);
 

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -29,9 +29,7 @@ MU_TEST(test_set_get_metrics) {
   mu_check(vimWindowGetHeight() == 21);
 
   vimWindowSetWidth(100);
-  printf("-- vimWindowSetHeight START --\n");
   vimWindowSetHeight(101);
-  printf("-- vimWindowSetHeight END --\n");
 
   mu_check(vimWindowGetWidth() == 100);
   mu_check(vimWindowGetHeight() == 101);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -11,26 +11,6 @@
 
 #include "vim.h"
 
-void vimInit(int argc, char **argv) {
-  mparm_T params;
-  vim_memset(&params, 0, sizeof(params));
-  params.argc = argc;
-  params.argv = argv;
-  params.want_full_screen = TRUE;
-  params.window_count = -1;
-
-  mch_early_init();
-  common_init(&params);
-
-  // Set to 'nocompatible' so we get the expected Vim undo / redo behavior,
-  // rather than Vi's behavior.
-  // See :help cpoptions and :help compatible for details
-  change_compatible(FALSE);
-
-  win_setwidth(80);
-  win_setheight(40);
-}
-
 buf_T *vimBufferOpen(char_u *ffname_arg, linenr_T lnum, int flags) {
   buf_T *buffer = buflist_new(ffname_arg, NULL, lnum, flags);
   set_curbuf(buffer, DOBUF_SPLIT);
@@ -244,4 +224,26 @@ int vimGetMode(void) { return get_real_state(); }
 
 void vimRegisterGet(int reg_name, int *num_lines, char_u ***lines) {
   get_yank_register_value(reg_name, num_lines, lines);
+}
+
+void vimInit(int argc, char **argv) {
+  mparm_T params;
+  vim_memset(&params, 0, sizeof(params));
+  params.argc = argc;
+  params.argv = argv;
+  params.want_full_screen = TRUE;
+  params.window_count = -1;
+
+  mch_early_init();
+  common_init(&params);
+
+  // Set to 'nocompatible' so we get the expected Vim undo / redo behavior,
+  // rather than Vi's behavior.
+  // See :help cpoptions and :help compatible for details
+  change_compatible(FALSE);
+
+  full_screen = TRUE;
+  screenalloc(FALSE);
+  vimWindowSetWidth(80);
+  vimWindowSetHeight(40);
 }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -83,7 +83,6 @@ void vimInput(char_u *input) {
   input = replace_termcodes((char_u *)input, &ptr, FALSE, TRUE, FALSE);
   p_cpo = cpo_save;
 
-
   if (*ptr != NUL) /* trailing CTRL-V results in nothing */
   {
     sm_execute_normal(input);
@@ -206,7 +205,7 @@ int vimWindowGetTopLine(void) { return curwin->w_topline; }
 
 void vimWindowSetWidth(int width) {
   if (width > Columns) {
-      Columns = width;
+    Columns = width;
   }
 
   win_new_width(curwin, width);
@@ -214,7 +213,7 @@ void vimWindowSetWidth(int width) {
 
 void vimWindowSetHeight(int height) {
   if (height > Rows) {
-      Rows = height;
+    Rows = height;
   }
 
   win_new_height(curwin, height);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -242,7 +242,7 @@ void vimInit(int argc, char **argv) {
   change_compatible(FALSE);
 
   full_screen = TRUE;
-  screenalloc(FALSE);
   vimWindowSetWidth(80);
   vimWindowSetHeight(40);
+  screenalloc(FALSE);
 }

--- a/src/option.c
+++ b/src/option.c
@@ -2888,7 +2888,7 @@ static struct vimoption options[] =
 			    {(char_u *)20L, (char_u *)0L} SCTX_INIT},
     {"wrap",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_WRAP,
-			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"wrapmargin",  "wm",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_wm, PV_WM,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},

--- a/src/window.c
+++ b/src/window.c
@@ -2941,7 +2941,6 @@ frame_new_height(
     int		extra_lines;
     int		h;
 
-    printf("frame_new_height - 1\n");
     if (topfrp->fr_win != NULL)
     {
 	/* Simple case: just one window. */
@@ -5097,8 +5096,6 @@ win_setheight_win(int height, win_T *win)
 {
     int		row;
 
-    printf("win_setheight_win: %d\n", height);
-
     if (win == curwin)
     {
 	/* Always keep current window at least one line high, even when
@@ -5109,11 +5106,8 @@ win_setheight_win(int height, win_T *win)
 	    height = 1;
 	height += WINBAR_HEIGHT(curwin);
     }
-    printf("win_setheight_win - 1: %d\n", height);
 
-    printf("win_setheight_win - 2: %d\n", win->w_height);
     frame_setheight(win->w_frame, height + win->w_status_height);
-    printf("win_setheight_win - 2.5: %d\n", win->w_height);
 
     /* recompute the window positions */
     row = win_comp_pos();
@@ -5129,9 +5123,6 @@ win_setheight_win(int height, win_T *win)
     msg_col = 0;
 
     redraw_all_later(NOT_VALID);
-
-    printf("win_setheight_win - 3: %d\n", win->w_height);
-
 }
 
 /*
@@ -5798,8 +5789,6 @@ win_new_height(win_T *wp, int height)
 {
     int		prev_height = wp->w_height;
 
-    printf("win_new_height - 1: %d\n", wp->w_height);
-
     /* Don't want a negative height.  Happens when splitting a tiny window.
      * Will equalize heights soon to fix it. */
     if (height < 0)
@@ -5807,7 +5796,6 @@ win_new_height(win_T *wp, int height)
     if (wp->w_height == height)
 	return;	    /* nothing to do */
 
-    printf("win_new_height - 2: %d\n", wp->w_height);
     if (wp->w_height > 0)
     {
 	if (wp == curwin)
@@ -5821,12 +5809,8 @@ win_new_height(win_T *wp, int height)
 	    set_fraction(wp);
     }
 
-    printf("win_new_height - 3: %d\n", wp->w_height);
-
     wp->w_height = height;
     wp->w_skipcol = 0;
-
-    printf("win_new_height - 4: %d\n", wp->w_height);
 
     /* There is no point in adjusting the scroll position when exiting.  Some
      * values might be invalid. */
@@ -5839,7 +5823,6 @@ win_new_height(win_T *wp, int height)
     void
 scroll_to_fraction(win_T *wp, int prev_height)
 {
-    printf("scroll_to_fraction - 1\n");
     linenr_T	lnum;
     int		sline, line_size;
     int		height = wp->w_height;
@@ -5876,8 +5859,6 @@ scroll_to_fraction(win_T *wp, int prev_height)
 		wp->w_wrow -= rows - line_size;
 	    }
 	}
-
-	printf("scroll_to_fraction - 2\n");
 
 	if (sline < 0)
 	{
@@ -5947,28 +5928,19 @@ scroll_to_fraction(win_T *wp, int prev_height)
 	set_topline(wp, lnum);
     }
 
-	printf("scroll_to_fraction - 3\n");
     if (wp == curwin)
     {
-	printf("scroll_to_fraction - 3.1\n");
 	if (get_scrolloff_value())
 	    update_topline();
-	printf("scroll_to_fraction - 3.2\n");
 	curs_columns(FALSE);	/* validate w_wrow */
-	printf("scroll_to_fraction - 3.3\n");
     }
     if (prev_height > 0)
 	wp->w_prev_fraction_row = wp->w_wrow;
 
-	printf("scroll_to_fraction - 4\n");
     win_comp_scroll(wp);
-	printf("scroll_to_fraction - 5\n");
     redraw_win_later(wp, SOME_VALID);
-	printf("scroll_to_fraction - 6\n");
     wp->w_redr_status = TRUE;
-	printf("scroll_to_fraction - 7\n");
     invalidate_botline_win(wp);
-    printf("scroll_to_fraction - done\n");
 }
 
 /*
@@ -6103,7 +6075,6 @@ last_status(
     static void
 last_status_rec(frame_T *fr, int statusline)
 {
-    printf("last_status_rec - 1\n");
     frame_T	*fp;
     win_T	*wp;
 

--- a/src/window.c
+++ b/src/window.c
@@ -2941,6 +2941,7 @@ frame_new_height(
     int		extra_lines;
     int		h;
 
+    printf("frame_new_height - 1\n");
     if (topfrp->fr_win != NULL)
     {
 	/* Simple case: just one window. */
@@ -5096,6 +5097,8 @@ win_setheight_win(int height, win_T *win)
 {
     int		row;
 
+    printf("win_setheight_win: %d\n", height);
+
     if (win == curwin)
     {
 	/* Always keep current window at least one line high, even when
@@ -5106,8 +5109,11 @@ win_setheight_win(int height, win_T *win)
 	    height = 1;
 	height += WINBAR_HEIGHT(curwin);
     }
+    printf("win_setheight_win - 1: %d\n", height);
 
+    printf("win_setheight_win - 2: %d\n", win->w_height);
     frame_setheight(win->w_frame, height + win->w_status_height);
+    printf("win_setheight_win - 2.5: %d\n", win->w_height);
 
     /* recompute the window positions */
     row = win_comp_pos();
@@ -5123,6 +5129,9 @@ win_setheight_win(int height, win_T *win)
     msg_col = 0;
 
     redraw_all_later(NOT_VALID);
+
+    printf("win_setheight_win - 3: %d\n", win->w_height);
+
 }
 
 /*
@@ -5789,6 +5798,8 @@ win_new_height(win_T *wp, int height)
 {
     int		prev_height = wp->w_height;
 
+    printf("win_new_height - 1: %d\n", wp->w_height);
+
     /* Don't want a negative height.  Happens when splitting a tiny window.
      * Will equalize heights soon to fix it. */
     if (height < 0)
@@ -5796,6 +5807,7 @@ win_new_height(win_T *wp, int height)
     if (wp->w_height == height)
 	return;	    /* nothing to do */
 
+    printf("win_new_height - 2: %d\n", wp->w_height);
     if (wp->w_height > 0)
     {
 	if (wp == curwin)
@@ -5809,18 +5821,25 @@ win_new_height(win_T *wp, int height)
 	    set_fraction(wp);
     }
 
+    printf("win_new_height - 3: %d\n", wp->w_height);
+
     wp->w_height = height;
     wp->w_skipcol = 0;
 
+    printf("win_new_height - 4: %d\n", wp->w_height);
+
     /* There is no point in adjusting the scroll position when exiting.  Some
      * values might be invalid. */
-    if (!exiting)
+    if (!exiting && 
+		    // libvim: Only reset scroll fraction if height was smaller than new height
+		    prev_height > wp->w_height)
 	scroll_to_fraction(wp, prev_height);
 }
 
     void
 scroll_to_fraction(win_T *wp, int prev_height)
 {
+    printf("scroll_to_fraction - 1\n");
     linenr_T	lnum;
     int		sline, line_size;
     int		height = wp->w_height;
@@ -5857,6 +5876,8 @@ scroll_to_fraction(win_T *wp, int prev_height)
 		wp->w_wrow -= rows - line_size;
 	    }
 	}
+
+	printf("scroll_to_fraction - 2\n");
 
 	if (sline < 0)
 	{
@@ -5926,19 +5947,28 @@ scroll_to_fraction(win_T *wp, int prev_height)
 	set_topline(wp, lnum);
     }
 
+	printf("scroll_to_fraction - 3\n");
     if (wp == curwin)
     {
+	printf("scroll_to_fraction - 3.1\n");
 	if (get_scrolloff_value())
 	    update_topline();
+	printf("scroll_to_fraction - 3.2\n");
 	curs_columns(FALSE);	/* validate w_wrow */
+	printf("scroll_to_fraction - 3.3\n");
     }
     if (prev_height > 0)
 	wp->w_prev_fraction_row = wp->w_wrow;
 
+	printf("scroll_to_fraction - 4\n");
     win_comp_scroll(wp);
+	printf("scroll_to_fraction - 5\n");
     redraw_win_later(wp, SOME_VALID);
+	printf("scroll_to_fraction - 6\n");
     wp->w_redr_status = TRUE;
+	printf("scroll_to_fraction - 7\n");
     invalidate_botline_win(wp);
+    printf("scroll_to_fraction - done\n");
 }
 
 /*
@@ -6073,6 +6103,7 @@ last_status(
     static void
 last_status_rec(frame_T *fr, int statusline)
 {
+    printf("last_status_rec - 1\n");
     frame_T	*fp;
     win_T	*wp;
 


### PR DESCRIPTION
__Issue:__ When integrating the 'topline' changes to Onivim2, I saw unpredictable scrolling behavior (when moving down with 'j', sometimes the topline would change, other times it wouldn't).

__Defect:__ Line wrap is turned on by default, but there is no line wrapping yet in Onivim 2's UI - this caused a disparity in the scroll behavior (some lines would take up multiple screen lines).

__Fix:__ Turn off wrap by default, for now.