### PR TITLE
Fix bug with abbrev/cabbrev expansion + tests

### DIFF
--- a/src/apitest/abbrev.c
+++ b/src/apitest/abbrev.c
@@ -1,0 +1,116 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void) {
+  vimInput("<Esc>");
+  vimInput("<Esc>");
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(insert_abbrev_multiple) {
+
+  vimExecute("iabbrev waht what");
+
+  vimInput("I");
+  vimInput("w");
+  vimInput("a");
+  vimInput("h");
+  vimInput("t");
+  vimInput(" ");
+  vimInput("w");
+  vimInput("a");
+  vimInput("h");
+  vimInput("t");
+  vimInput(" ");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "what what This is the first line of a test file") == 0);
+}
+
+MU_TEST(insert_abbrev_no_recursive) {
+  vimExecute("iabbrev waht what");
+  vimExecute("iabbrev what what2");
+
+  vimInput("I");
+  vimInput("w");
+  vimInput("a");
+  vimInput("h");
+  vimInput("t");
+  vimInput(" ");
+  vimInput("w");
+  vimInput("h");
+  vimInput("a");
+  vimInput("t");
+  vimInput(" ");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "what what2 This is the first line of a test file") == 0);
+}
+
+MU_TEST(insert_abbrev_expr) {
+  vimExecute("iabbrev <expr> waht col('.')");
+
+  vimInput("I");
+  vimInput("w");
+  vimInput("a");
+  vimInput("h");
+  vimInput("t");
+  vimInput(" ");
+  vimInput("w");
+  vimInput("a");
+  vimInput("h");
+  vimInput("t");
+  vimInput(" ");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "5 7 This is the first line of a test file") == 0);
+}
+
+MU_TEST(command_abbrev) {
+  vimExecute("cabbrev abc def");
+
+  vimInput(":");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput(" ");
+  vimInput("a");
+  vimInput("b");
+  vimInput("c");
+  vimInput(" ");
+
+  char_u *line = vimCommandLineGetText();
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "def def ") == 0);
+}
+
+MU_TEST_SUITE(test_suite) {
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(insert_abbrev_multiple);
+  MU_RUN_TEST(insert_abbrev_no_recursive);
+  MU_RUN_TEST(insert_abbrev_expr);
+  MU_RUN_TEST(command_abbrev);
+}
+
+int main(int argc, char **argv) {
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  buf_T *buf = vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/state_machine.c
+++ b/src/state_machine.c
@@ -67,6 +67,10 @@ void sm_execute(char_u *keys) {
   char_u *keys_esc = vim_strsave_escape_csi(keys);
   ins_typebuf(keys_esc, REMAP_YES, 0, FALSE, FALSE);
 
+  // Reset abbr_cnt after each input here,
+  // to enable correct cabbrev expansions
+  typebuf.tb_no_abbr_cnt = 0;
+
   if (state_current != NULL) {
     while (vpeekc() != NUL) {
       int c = vgetc();


### PR DESCRIPTION
__Issue:__ `abbrev` and family (`iabbrev`, `cabbrev`, etc) would only expand a single time, and then they would fail to expand.

__Fix:__ On `libvim` user input - reset the `typebuf.tb_no_abbr_cnt` to always enable expansion on user keypress.