### PR TITLE
Disable exmode for now

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -475,6 +475,9 @@ restore_dbg_stuff(struct dbg_stuff *dsp)
 do_exmode(
     int		improved)	    /* TRUE for "improved Ex" mode */
 {
+    /* libvim - disable exmode for now */
+    return;
+
     int		save_msg_scroll;
     int		prev_msg_row;
     linenr_T	prev_line;

--- a/src/normal.c
+++ b/src/normal.c
@@ -258,7 +258,6 @@ static const struct nv_cmd {
     {'N', nv_next, 0, SEARCH_REV},
     {'O', nv_open, 0, 0},
     {'P', nv_put, 0, 0},
-    {'Q', nv_exmode, NV_NCW, 0},
     {'R', nv_Replace, 0, FALSE},
     {'S', nv_subst, NV_KEEPREG, 0},
     {'T', nv_csearch, NV_NCH_ALW | NV_LANG, BACKWARD},
@@ -3667,19 +3666,6 @@ static void nv_hor_scrollbar(cmdarg_T *cap) {
 #endif
 
 /*
- * "Q" command.
- */
-static void nv_exmode(cmdarg_T *cap) {
-  /*
-   * Ignore 'Q' in Visual mode, just give a beep.
-   */
-  if (VIsual_active)
-    vim_beep(BO_EX);
-  else if (!checkclearop(cap->oap))
-    do_exmode(FALSE);
-}
-
-/*
  * Handle a ":" command.
  */
 static void nv_colon(cmdarg_T *cap) {
@@ -6189,18 +6175,6 @@ static void nv_g_cmd(cmdarg_T *cap) {
     goto_byte(cap->count0);
     break;
 #endif
-
-  /* "gQ": improved Ex mode */
-  case 'Q':
-    if (text_locked()) {
-      clearopbeep(cap->oap);
-      text_locked_msg();
-      break;
-    }
-
-    if (!checkclearopq(oap))
-      do_exmode(TRUE);
-    break;
 
 #ifdef FEAT_JUMPLIST
   case ',':


### PR DESCRIPTION
The `exmode` command (via `Q`, `gQ`, etc) doesn't work correctly in `libvim` - it uses the legacy cmdline code path that has blocking input, which causes a hang.

For now, we'll disable `exmode` such that `Q`, `gQ` are no-ops. We can re-introduce it and re-integrate it with the state machine if there is demand for it.