### PR TITLE
Bugfix: When insertSpaces is false, spaces still get inserted

### DIFF
--- a/src/libvim.c
+++ b/src/libvim.c
@@ -214,6 +214,10 @@ void vimOptionSetTabSize(int tabSize) {
 
 void vimOptionSetInsertSpaces(int insertSpaces) {
   curbuf->b_p_et = insertSpaces;
+
+  if (!insertSpaces) {
+    curbuf->b_p_sts = 0;
+  }
 }
 
 int vimOptionGetTabSize() { return curbuf->b_p_ts; }


### PR DESCRIPTION
__Issue:__ After setting the indent size via `vimOptionSetIndentSize`, and then setting `vimOptionSetExpandSpaces` to `false`, there are buffer updates sent with spaces mixed in with tabs.

__Fix:__ Disable `softtabstop` by setting it to `0` when in the `noexpandtab` mode