### PR TITLE
Regression Test: Control+q / Control+Q

### DIFF
--- a/src/apitest/visual_mode.c
+++ b/src/apitest/visual_mode.c
@@ -66,11 +66,29 @@ MU_TEST(test_characterwise_range) {
   mu_check(end.col == 2);
 }
 
+MU_TEST(test_ctrl_q) {
+  vimInput("<c-q>");
+  
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
+  mu_check(vimVisualGetType() == Ctrl_V);
+  mu_check(vimVisualIsActive() == 1);
+}
+
+MU_TEST(test_ctrl_Q) {
+  vimInput("<c-Q>");
+  
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
+  mu_check(vimVisualGetType() == Ctrl_V);
+  mu_check(vimVisualIsActive() == 1);
+}
+
 MU_TEST_SUITE(test_suite) {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_visual_is_active);
   MU_RUN_TEST(test_characterwise_range);
+  MU_RUN_TEST(test_ctrl_q);
+  MU_RUN_TEST(test_ctrl_Q);
 }
 
 int main(int argc, char **argv) {

--- a/src/apitest/visual_mode.c
+++ b/src/apitest/visual_mode.c
@@ -68,7 +68,7 @@ MU_TEST(test_characterwise_range) {
 
 MU_TEST(test_ctrl_q) {
   vimInput("<c-q>");
-  
+
   mu_check((vimGetMode() & VISUAL) == VISUAL);
   mu_check(vimVisualGetType() == Ctrl_V);
   mu_check(vimVisualIsActive() == 1);
@@ -76,7 +76,7 @@ MU_TEST(test_ctrl_q) {
 
 MU_TEST(test_ctrl_Q) {
   vimInput("<c-Q>");
-  
+
   mu_check((vimGetMode() & VISUAL) == VISUAL);
   mu_check(vimVisualGetType() == Ctrl_V);
   mu_check(vimVisualIsActive() == 1);


### PR DESCRIPTION
There was a crash previously around `<c-q>`/`<c-Q>`, this is a regression test to validate the correct behavior (switch to visual blockwise mode).