### PR TITLE
API: Externalize 'quit'

### DIFF
--- a/src/apitest/quit.c
+++ b/src/apitest/quit.c
@@ -1,0 +1,66 @@
+#include "libvim.h"
+#include "minunit.h"
+
+static int quitCount = 0;
+static int lastForce = 0;
+static buf_T *lastQuitBuf = 0;
+
+void onQuit(buf_T *buffer, int force)
+{
+
+  lastQuitBuf = buffer;
+  lastForce = force;
+  quitCount++;
+}
+
+void test_setup(void)
+{
+  vimExecute("e!");
+  vimInput("g");
+  vimInput("g");
+  quitCount = 0;
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_q)
+{
+  vimExecute("q");
+
+  mu_check(quitCount == 1);
+  mu_check(lastQuitBuf == curbuf);
+  mu_check(lastForce == FALSE);
+}
+
+MU_TEST(test_q_force)
+{
+  vimExecute("q!");
+  
+  mu_check(quitCount == 1);
+  mu_check(lastQuitBuf == curbuf);
+  mu_check(lastForce == TRUE);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_q);
+  MU_RUN_TEST(test_q_force);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  vimSetQuitCallback(&onQuit);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/quit.c
+++ b/src/apitest/quit.c
@@ -35,7 +35,7 @@ MU_TEST(test_q)
 MU_TEST(test_q_force)
 {
   vimExecute("q!");
-  
+
   mu_check(quitCount == 1);
   mu_check(lastQuitBuf == curbuf);
   mu_check(lastForce == TRUE);
@@ -44,7 +44,7 @@ MU_TEST(test_q_force)
 MU_TEST(test_xall)
 {
   vimExecute("xall");
-  
+
   mu_check(quitCount == 1);
   mu_check(lastQuitBuf == NULL);
   mu_check(lastForce == FALSE);
@@ -53,7 +53,7 @@ MU_TEST(test_xall)
 MU_TEST(test_xit)
 {
   vimExecute("xit!");
-  
+
   mu_check(quitCount == 1);
   mu_check(lastQuitBuf == curbuf);
   mu_check(lastForce == TRUE);

--- a/src/apitest/quit.c
+++ b/src/apitest/quit.c
@@ -41,12 +41,32 @@ MU_TEST(test_q_force)
   mu_check(lastForce == TRUE);
 }
 
+MU_TEST(test_xall)
+{
+  vimExecute("xall");
+  
+  mu_check(quitCount == 1);
+  mu_check(lastQuitBuf == NULL);
+  mu_check(lastForce == FALSE);
+}
+
+MU_TEST(test_xit)
+{
+  vimExecute("xit!");
+  
+  mu_check(quitCount == 1);
+  mu_check(lastQuitBuf == curbuf);
+  mu_check(lastForce == TRUE);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_q);
   MU_RUN_TEST(test_q_force);
+  MU_RUN_TEST(test_xall);
+  MU_RUN_TEST(test_xit);
 }
 
 int main(int argc, char **argv)

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3440,8 +3440,9 @@ void do_wqall(exarg_T *eap)
   }
   if (exiting)
   {
-    if (!error)
-      getout(0); /* exit Vim */
+    if (quitCallback != NULL) {
+      quitCallback(NULL, eap->forceit);
+    }
     not_exiting();
   }
 }

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3440,7 +3440,8 @@ void do_wqall(exarg_T *eap)
   }
   if (exiting)
   {
-    if (quitCallback != NULL) {
+    if (quitCallback != NULL)
+    {
       quitCallback(NULL, eap->forceit);
     }
     not_exiting();

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5565,7 +5565,7 @@ ex_quit(exarg_T *eap)
 
   if (quitCallback != NULL)
   {
-     quitCallback(wp->w_buffer, eap->forceit);
+    quitCallback(wp->w_buffer, eap->forceit);
   }
 
   not_exiting();
@@ -5599,12 +5599,12 @@ ex_quit_all(exarg_T *eap)
 
   exiting = TRUE;
 
-  if (quitCallback != NULL) {
+  if (quitCallback != NULL)
+  {
     quitCallback(NULL, eap->forceit);
   }
-  
+
   not_exiting();
-  
 }
 
 /*
@@ -5994,10 +5994,11 @@ ex_exit(exarg_T *eap)
   }
   else
   {
-     if (quitCallback != NULL) {
-       quitCallback(curbuf, eap->forceit);
-     }
-     
+    if (quitCallback != NULL)
+    {
+      quitCallback(curbuf, eap->forceit);
+    }
+
     not_exiting();
   }
 }

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,7 +49,7 @@ EXTERN AutoCommandCallback autoCommandCallback INIT(= NULL);
 EXTERN BufferUpdateCallback bufferUpdateCallback INIT(= NULL);
 EXTERN DirectoryChangedCallback directoryChangedCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
-EXTERN QuitCallback quitCallback INIT=(NULL);
+EXTERN QuitCallback quitCallback INIT(= NULL);
 
 /*
  * Globals for managing the state machine

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,6 +49,7 @@ EXTERN AutoCommandCallback autoCommandCallback INIT(= NULL);
 EXTERN BufferUpdateCallback bufferUpdateCallback INIT(= NULL);
 EXTERN DirectoryChangedCallback directoryChangedCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
+EXTERN QuitCallback quitCallback INIT=(NULL);
 
 /*
  * Globals for managing the state machine

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -61,6 +61,11 @@ void vimSetDirectoryChangedCallback(DirectoryChangedCallback f)
   directoryChangedCallback = f;
 }
 
+void vimSetQuitCallback(QuitCallback f)
+{
+  quitCallback = f;
+}
+
 char_u vimCommandLineGetType(void) { return ccline.cmdfirstc; }
 
 char_u *vimCommandLineGetText(void) { return ccline.cmdbuff; }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -87,6 +87,18 @@ void vimSetMessageCallback(MessageCallback messageCallback);
 
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
 
+/*
+ * vimSetQuitCallback
+ *
+ * Called when a `:q`, `:qa`, `:q!` is called
+ * 
+ * It is up to the libvim consumer how to handle the 'quit' call.
+ * There are two arguments passed:
+ * - `buffer`: the buffer quit was requested for
+ * - `force`: a boolean if the command was forced (ie, if `q!` was used)
+ */
+void vimSetQuitCallback(QuitCallback callback);
+
 /***
  * Options
  **/

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -86,6 +86,7 @@ void vimSetMessageCallback(MessageCallback messageCallback);
  **/
 
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
+void vimSetQuitCallback(QuitCallback callback);
 
 /*
  * vimSetQuitCallback

--- a/src/structs.h
+++ b/src/structs.h
@@ -2387,6 +2387,7 @@ typedef void (*BufferUpdateCallback)(bufferUpdate_T bufferUpdate);
 
 typedef void (*MessageCallback)(char_u *title, char_u *msg, msgPriority_T priority);
 typedef void (*DirectoryChangedCallback)(char_u *path);
+typedef void (*QuitCallback)(buf_T *buf, int isForced);
 
 #ifdef FEAT_DIFF
 /*


### PR DESCRIPTION
This change 'externalizes' the quit gesture, and related gestures, like:
- `:quit`
- `:quitall`
- `:wq`
- `:xall`
- `:xit`
- `:exit`
- `ZZ`
etc

This puts the burden of actually 'quitting' on the consumer of libvim - libvim doesn't actually quit the process. For commands that save, like `:wq`, `libvim` will handle the save aspect, and then forward the quit request to the `libvim` consumer.