### PR TITLE
Feature: vimWindowSetTopLeft API

### DIFF
--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -131,6 +131,72 @@ MU_TEST(test_only_scroll_at_boundary)
   mu_check(vimWindowGetTopLine() == 2);
 }
 
+MU_TEST(test_no_scroll_after_setting_topline) 
+{
+  vimWindowSetWidth(10);
+  vimWindowSetHeight(10);
+  
+  pos_T pos;
+  pos.lnum = 95;
+  pos.col = 1;
+
+  vimCursorSetPosition(pos);
+
+  vimWindowSetTopLeft(90, 1);
+
+  mu_check(vimWindowGetTopLine() == 90);
+  vimInput("j");
+  
+  mu_check(vimWindowGetTopLine() == 90);
+  mu_check(vimCursorGetLine() == 96);
+}
+
+MU_TEST(test_scroll_left_at_boundary) 
+{
+  vimWindowSetWidth(4);
+  vimWindowSetHeight(10);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 0);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 0);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 0);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 1);
+  
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 2);
+}
+
+MU_TEST(test_no_scroll_after_setting_left) 
+{
+  vimWindowSetWidth(4);
+  vimWindowSetHeight(10);
+
+  pos_T pos;
+  pos.lnum = 99;
+  pos.col = 2;
+  vimCursorSetPosition(pos);
+
+  vimWindowSetTopLeft(1, 2);
+  
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 2);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 2);
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 2);
+  
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 3);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -140,6 +206,9 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_small_screen_scroll);
   MU_RUN_TEST(test_h_m_l);
   MU_RUN_TEST(test_only_scroll_at_boundary);
+  MU_RUN_TEST(test_no_scroll_after_setting_topline);
+  MU_RUN_TEST(test_scroll_left_at_boundary);
+  MU_RUN_TEST(test_no_scroll_after_setting_left);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -131,11 +131,11 @@ MU_TEST(test_only_scroll_at_boundary)
   mu_check(vimWindowGetTopLine() == 2);
 }
 
-MU_TEST(test_no_scroll_after_setting_topline) 
+MU_TEST(test_no_scroll_after_setting_topline)
 {
   vimWindowSetWidth(10);
   vimWindowSetHeight(10);
-  
+
   pos_T pos;
   pos.lnum = 95;
   pos.col = 1;
@@ -146,12 +146,12 @@ MU_TEST(test_no_scroll_after_setting_topline)
 
   mu_check(vimWindowGetTopLine() == 90);
   vimInput("j");
-  
+
   mu_check(vimWindowGetTopLine() == 90);
   mu_check(vimCursorGetLine() == 96);
 }
 
-MU_TEST(test_scroll_left_at_boundary) 
+MU_TEST(test_scroll_left_at_boundary)
 {
   vimWindowSetWidth(4);
   vimWindowSetHeight(10);
@@ -167,12 +167,12 @@ MU_TEST(test_scroll_left_at_boundary)
 
   vimInput("l");
   mu_check(vimWindowGetLeftColumn() == 1);
-  
+
   vimInput("l");
   mu_check(vimWindowGetLeftColumn() == 2);
 }
 
-MU_TEST(test_no_scroll_after_setting_left) 
+MU_TEST(test_no_scroll_after_setting_left)
 {
   vimWindowSetWidth(4);
   vimWindowSetHeight(10);
@@ -183,16 +183,16 @@ MU_TEST(test_no_scroll_after_setting_left)
   vimCursorSetPosition(pos);
 
   vimWindowSetTopLeft(1, 2);
-  
-  vimInput("l");
-  mu_check(vimWindowGetLeftColumn() == 2);
 
   vimInput("l");
   mu_check(vimWindowGetLeftColumn() == 2);
 
   vimInput("l");
   mu_check(vimWindowGetLeftColumn() == 2);
-  
+
+  vimInput("l");
+  mu_check(vimWindowGetLeftColumn() == 2);
+
   vimInput("l");
   mu_check(vimWindowGetLeftColumn() == 3);
 }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -128,6 +128,7 @@ void vimInput(char_u *input)
   }
 
   update_curswant();
+  curs_columns(TRUE);
 }
 
 int vimVisualIsActive(void) { return VIsual_active; }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -268,7 +268,8 @@ int vimWindowGetHeight(void) { return curwin->w_height; }
 int vimWindowGetTopLine(void) { return curwin->w_topline; }
 int vimWindowGetLeftColumn(void) { return curwin->w_leftcol; }
 
-void vimWindowSetTopLeft(int top, int left) {
+void vimWindowSetTopLeft(int top, int left)
+{
   curwin->w_topline = top;
   curwin->w_leftcol = left;
   curs_columns(TRUE);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -265,6 +265,13 @@ int vimOptionGetInsertSpaces(void) { return curbuf->b_p_et; }
 int vimWindowGetWidth(void) { return curwin->w_width; }
 int vimWindowGetHeight(void) { return curwin->w_height; }
 int vimWindowGetTopLine(void) { return curwin->w_topline; }
+int vimWindowGetLeftColumn(void) { return curwin->w_leftcol; }
+
+void vimWindowSetTopLeft(int top, int left) {
+  curwin->w_topline = top;
+  curwin->w_leftcol = left;
+  curs_columns(TRUE);
+}
 
 void vimWindowSetWidth(int width)
 {

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -169,9 +169,12 @@ char_u *vimSearchGetPattern();
 int vimWindowGetWidth(void);
 int vimWindowGetHeight(void);
 int vimWindowGetTopLine(void);
+int vimWindowGetLeftColumn(void);
 
 void vimWindowSetWidth(int width);
 void vimWindowSetHeight(int height);
+
+void vimWindowSetTopLeft(int top, int left);
 
 /***
  * Misc

--- a/src/option.c
+++ b/src/option.c
@@ -1949,7 +1949,7 @@ static struct vimoption options[] =
         {"showmatch", "sm", P_BOOL | P_VI_DEF, (char_u *)&p_sm, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
         {"showmode", "smd", P_BOOL | P_VIM, (char_u *)&p_smd, PV_NONE, {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
         {"showtabline", "stal", P_NUM | P_VI_DEF | P_RALL, (char_u *)&p_stal, PV_NONE, {(char_u *)1L, (char_u *)0L} SCTX_INIT},
-        {"sidescroll", "ss", P_NUM | P_VI_DEF, (char_u *)&p_ss, PV_NONE, {(char_u *)0L, (char_u *)0L} SCTX_INIT},
+        {"sidescroll", "ss", P_NUM | P_VI_DEF, (char_u *)&p_ss, PV_NONE, {(char_u *)1L, (char_u *)0L} SCTX_INIT},
         {"sidescrolloff", "siso", P_NUM | P_VI_DEF | P_VIM | P_RBUF, (char_u *)&p_siso, PV_SISO, {(char_u *)0L, (char_u *)0L} SCTX_INIT},
         {"signcolumn", "scl", P_STRING | P_ALLOCED | P_VI_DEF | P_RWIN,
 #ifdef FEAT_SIGNS


### PR DESCRIPTION
This adds an API to set the topline / leftcol via `libvim.h`.

It also changes the default of `sidescroll` to 1, which is a more natural horizontal scroll behavior when we're not limited by terminal redraw speed.