### PR TITLE
Bugfix: Control+V (insert literal) would hang

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -605,6 +605,7 @@ OBJ = \
 	$(OUTDIR)/search.o \
 	$(OUTDIR)/sha256.o \
 	$(OUTDIR)/sign.o \
+	$(OUTDIR)/state_insert_literal.o \
 	$(OUTDIR)/state_machine.o \
 	$(OUTDIR)/syntax.o \
 	$(OUTDIR)/tag.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1486,6 +1486,7 @@ BASIC_SRC = \
 	search.c \
 	sha256.c \
 	sign.c \
+	state_insert_literal.c \
 	state_machine.c \
 	syntax.c \
 	tag.c \
@@ -1594,6 +1595,7 @@ OBJ_COMMON = \
 	objects/search.o \
 	objects/sha256.o \
 	objects/sign.o \
+	objects/state_insert_literal.o \
 	objects/state_machine.o \
 	objects/syntax.o \
 	objects/tag.o \
@@ -2972,6 +2974,9 @@ objects/sha256.o: sha256.c
 
 objects/sign.o: sign.c
 	$(CCC) -o $@ sign.c
+
+objects/state_insert_literal.o: state_insert_literal.c
+	$(CCC) -o $@ state_insert_literal.c
 
 objects/state_machine.o: state_machine.c
 	$(CCC) -o $@ state_machine.c

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -128,19 +128,30 @@ MU_TEST(insert_mode_ctrlv)
   // Character literal mode
   vimInput("<c-v>");
 
-  // While a character literal is pending, a `^` is shown temporarily
-  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  mu_check(strcmp(line, "^") == 0);
-
   vimInput("1");
   vimInput("2");
   vimInput("6");
 
-  line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
   printf("LINE: %s\n", line);
   mu_check(strcmp(line, "~") == 0);
-  
+}
+
+MU_TEST(insert_mode_ctrlv_no_digit)
+{
+  vimInput("O");
+
+  // Character literal mode
+  vimInput("<c-v>");
+
+  // Jump out of character literal mode by entering a non-digit character
+  vimInput("a");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "a") == 0);
 }
 
 MU_TEST_SUITE(test_suite)
@@ -155,6 +166,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_end);
   MU_RUN_TEST(insert_changed_ticks);
   MU_RUN_TEST(insert_mode_ctrlv);
+  MU_RUN_TEST(insert_mode_ctrlv_no_digit);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -154,6 +154,20 @@ MU_TEST(insert_mode_ctrlv_no_digit)
   mu_check(strcmp(line, "a") == 0);
 }
 
+MU_TEST(insert_mode_ctrlv_newline)
+{
+  vimInput("O");
+
+  // Character literal mode
+  vimInput("<c-v>");
+
+  // Jump out of character literal mode by entering a non-digit character
+  vimInput("<cr>");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  mu_check(line[0] == 13);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -167,6 +181,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_changed_ticks);
   MU_RUN_TEST(insert_mode_ctrlv);
   MU_RUN_TEST(insert_mode_ctrlv_no_digit);
+  MU_RUN_TEST(insert_mode_ctrlv_newline);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -120,6 +120,29 @@ MU_TEST(insert_changed_ticks)
   mu_check(newVersion == initialVersion + 3);
 }
 
+/* Ctrl_v inserts a character literal */
+MU_TEST(insert_mode_ctrlv)
+{
+  vimInput("O");
+
+  // Character literal mode
+  vimInput("<c-v>");
+
+  // While a character literal is pending, a `^` is shown temporarily
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  mu_check(strcmp(line, "^") == 0);
+
+  vimInput("1");
+  vimInput("2");
+  vimInput("6");
+
+  line = vimBufferGetLine(curbuf, vimCursorGetLine());
+
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "~") == 0);
+  
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -131,6 +154,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_cr);
   MU_RUN_TEST(insert_end);
   MU_RUN_TEST(insert_changed_ticks);
+  MU_RUN_TEST(insert_mode_ctrlv);
 }
 
 int main(int argc, char **argv)

--- a/src/edit.c
+++ b/src/edit.c
@@ -373,13 +373,11 @@ void state_edit_cleanup(void *ctx)
 executionStatus_T state_edit_execute(void *ctx, int c)
 {
   editState_T *context = (editState_T *)ctx;
-  printf("state_edit_execute - c: %d\n", c);
 
   /* If we are coming back ctrl-v, handle that */
 
   if (context->is_ctrlv)
   {
-    printf("state_edit_execute - coming back from ctrl_v. c is: |%d| and ret is |%d|\n", c, context->ctrlv_ret);
     insert_special(context->ctrlv_ret, FALSE, TRUE);
 #ifdef FEAT_RIGHTLEFT
     revins_chars++;

--- a/src/edit.c
+++ b/src/edit.c
@@ -373,11 +373,13 @@ void state_edit_cleanup(void *ctx)
 executionStatus_T state_edit_execute(void *ctx, int c)
 {
   editState_T *context = (editState_T *)ctx;
+  printf("state_edit_execute - c: %d\n", c);
 
   /* If we are coming back ctrl-v, handle that */
 
   if (context->is_ctrlv)
   {
+    printf("state_edit_execute - coming back from ctrl_v. c is: |%d| and ret is |%d|\n", c, context->ctrlv_ret);
     insert_special(context->ctrlv_ret, FALSE, TRUE);
 #ifdef FEAT_RIGHTLEFT
     revins_chars++;

--- a/src/proto.h
+++ b/src/proto.h
@@ -163,6 +163,7 @@ void qsort(void *base, size_t elm_count, size_t elm_size, int (*cmp)(const void 
 #ifdef FEAT_SIGNS
 #include "sign.pro"
 #endif
+#include "state_insert_literal.pro"
 #include "state_machine.pro"
 #include "syntax.pro"
 #include "tag.pro"

--- a/src/proto/state_insert_literal.pro
+++ b/src/proto/state_insert_literal.pro
@@ -1,18 +1,9 @@
-/* state_machine.c */
+/* state_insert_literal.c */
 
-void sm_push(int mode, void *context, state_execute executeFn,
-             state_cleanup cleanupFn);
+void *state_insert_literal_initialize(int *ret);
 
-void sm_push_insert(int cmdchar, int startln, long count);
-void sm_push_normal();
-void sm_push_change(oparg_T *oap);
-void sm_push_cmdline(int cmdchar, long count, int indent);
+executionStatus_T state_insert_literal_execute(void *ctx, int c);
 
-void sm_execute_normal(char_u *keys);
-void sm_execute(char_u *key);
-
-int sm_get_current_mode(void);
-
-sm_T *sm_get_current(void);
+void state_insert_literal_cleanup(void *ctx);
 
 /* vim: set ft=c : */

--- a/src/proto/state_insert_literal.pro
+++ b/src/proto/state_insert_literal.pro
@@ -1,0 +1,18 @@
+/* state_machine.c */
+
+void sm_push(int mode, void *context, state_execute executeFn,
+             state_cleanup cleanupFn);
+
+void sm_push_insert(int cmdchar, int startln, long count);
+void sm_push_normal();
+void sm_push_change(oparg_T *oap);
+void sm_push_cmdline(int cmdchar, long count, int indent);
+
+void sm_execute_normal(char_u *keys);
+void sm_execute(char_u *key);
+
+int sm_get_current_mode(void);
+
+sm_T *sm_get_current(void);
+
+/* vim: set ft=c : */

--- a/src/proto/state_machine.pro
+++ b/src/proto/state_machine.pro
@@ -4,6 +4,7 @@ void sm_push(int mode, void *context, state_execute executeFn,
              state_cleanup cleanupFn);
 
 void sm_push_insert(int cmdchar, int startln, long count);
+void sm_push_insert_literal(int* ret);
 void sm_push_normal();
 void sm_push_change(oparg_T *oap);
 void sm_push_cmdline(int cmdchar, long count, int indent);

--- a/src/proto/state_machine.pro
+++ b/src/proto/state_machine.pro
@@ -4,7 +4,7 @@ void sm_push(int mode, void *context, state_execute executeFn,
              state_cleanup cleanupFn);
 
 void sm_push_insert(int cmdchar, int startln, long count);
-void sm_push_insert_literal(int* ret);
+void sm_push_insert_literal(int *ret);
 void sm_push_normal();
 void sm_push_change(oparg_T *oap);
 void sm_push_cmdline(int cmdchar, long count, int indent);

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -1,0 +1,129 @@
+/* vi:set ts=8 sts=4 sw=4 noet:
+ *
+ * state_machine
+ */
+
+/*
+ * Manage current input state
+ */
+
+#include "vim.h"
+
+typedef struct
+{
+  int cc;
+  int nc;
+  int i;
+  int hex;
+  int octal;
+  int unicode;
+  int *ret;
+} insertLiteral_T;
+
+insertLiteral_T *state_insert_literal_initialize(int *ret)
+{
+
+  insertLiteral_T *context = (insertLiteral_T *)alloc(sizeof(insertLiteral_T));
+  context->hex = FALSE;
+  context->octal = FALSE;
+
+  ++no_mapping;
+
+  context->cc = 0;
+  context->i = 0;
+  context->nc = 0;
+  context->ret = ret;
+
+  return context;
+}
+
+executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
+{
+  context->nc = nc;
+
+  if (context->nc == 'x' || context->nc == 'X')
+  {
+    context->hex = TRUE;
+  }
+  else if (context->nc == 'o' || context->nc == 'O')
+  {
+    context->octal = TRUE;
+  }
+  else if (context->nc == 'u' || context->nc == 'U')
+  {
+    context->unicode = TRUE
+  }
+  else
+  {
+    if (context->hex || context->unicode != 0)
+    {
+      if (!vim_isxdigit(context->nc))
+        return COMPLETED_UNHANDLED;
+      context->cc = context->cc * 16 + hex2nr(context_ > nc);
+    }
+    else if (context->octal)
+    {
+      if (context->nc < '0' || context->nc > '7')
+      {
+        return COMPLETED_UNHANDLED;
+      }
+
+      context->cc = context->cc * 8 + context->nc - '0';
+    }
+    else
+    {
+      if (!VIM_ISDIGIT(context->nc))
+      {
+        return COMPLETED;
+      }
+      context->cc = context->cc * 10 + context->nc - '0';
+    }
+
+    context->i++;
+  }
+
+  if (context->cc > 255 && context->unicode == 0)
+  {
+    context->cc = 255; /* limit range to 0-255 */
+  }
+
+  context->nc = 0;
+
+  if (context->hex)
+  {
+    if (context->i >= 2)
+      return COMPLETED_UNHANDLED;
+  }
+  else if (context->unicode)
+  { /* Unicode: up to four or eight chars */
+    if ((context->unicode == 'u' && context->i >= 4) || (context->unicode == 'U' && context->i >= 8))
+      return COMPLETED_UNHANDLED;
+  }
+  else if (context->i >= 3) /* decimal or octal: up to three chars */
+  {
+    return COMPLETED_UNHANDLED;
+  }
+
+  return HANDLED;
+}
+
+void state_insert_literal_cleanup(insertLiteral_T *context)
+{
+
+  if (context->i == 0) /* no number entered */
+  {
+    if (context->nc == K_ZERO) /* NUL is stored as NL */
+    {
+context->cc = '\n';
+context->nc = 0;
+    } else {
+    context->cc = context->nc;
+    context->nc = 0;
+    }
+  }
+
+   *(context->ret) = context->cc;
+
+  --no_mapping;
+  vim_free(context);
+}

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -37,6 +37,7 @@ void *state_insert_literal_initialize(int *ret)
   return context;
 }
 
+
 executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
   insertLiteral_T *context = (insertLiteral_T *)ctx;
@@ -58,6 +59,10 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   {
     if (context->hex || context->unicode != 0)
     {
+      /* We return COMPLETED_UNHANDLED here so that the last key press
+       * can be processed by insert mode. The insert mode state machine will
+       * pick it up, insert whatever it needs to from `context->ret`, and
+       * take care of returning HANDLED */
       if (!vim_isxdigit(context->nc))
         return COMPLETED_UNHANDLED;
       context->cc = context->cc * 16 + hex2nr(context->nc);

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -26,6 +26,7 @@ void *state_insert_literal_initialize(int *ret)
   insertLiteral_T *context = (insertLiteral_T *)alloc(sizeof(insertLiteral_T));
   context->hex = FALSE;
   context->octal = FALSE;
+  context->unicode = FALSE;
 
   ++no_mapping;
 

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -81,7 +81,7 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
     }
     else
     {
-      
+
       printf("state_insert_literal_execute - else block 2\n");
       printf(" - VIM_ISDIGIT(context->nc): %d\n", VIM_ISDIGIT(context->nc));
       if (!VIM_ISDIGIT(context->nc))

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -107,9 +107,11 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   }
   else if (context->i >= 3) /* decimal or octal: up to three chars */
   {
+    printf("state_insert_literal_execute - leaving after 3 decimal / octal chars\n");
     return COMPLETED_UNHANDLED;
   }
 
+  printf("state_insert_literal_execute - returning HANDLED\n");
   return HANDLED;
 }
 

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -51,7 +51,7 @@ executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
   }
   else if (context->nc == 'u' || context->nc == 'U')
   {
-    context->unicode = TRUE
+    context->unicode = TRUE;
   }
   else
   {
@@ -59,7 +59,7 @@ executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
     {
       if (!vim_isxdigit(context->nc))
         return COMPLETED_UNHANDLED;
-      context->cc = context->cc * 16 + hex2nr(context_ > nc);
+      context->cc = context->cc * 16 + hex2nr(context->nc);
     }
     else if (context->octal)
     {

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -39,6 +39,7 @@ void *state_insert_literal_initialize(int *ret)
 
 executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
+  printf("state_insert_literal_execute - c: |%d|\n", c);
   insertLiteral_T *context = (insertLiteral_T *)ctx;
   context->nc = nc;
 
@@ -130,6 +131,7 @@ void state_insert_literal_cleanup(void *ctx)
     }
   }
 
+  printf("state_insert_literal_cleanup: |%d|\n", context->cc);
   *(context->ret) = context->cc;
 
   --no_mapping;

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -39,7 +39,7 @@ void *state_insert_literal_initialize(int *ret)
 
 executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
-  printf("state_insert_literal_execute - c: |%d|\n", c);
+  printf("state_insert_literal_execute - c: |%d|\n", nc);
   insertLiteral_T *context = (insertLiteral_T *)ctx;
   context->nc = nc;
 

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -57,6 +57,7 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   }
   else
   {
+    printf("state_insert_literal_execute - else block 1\n");
     if (context->hex || context->unicode != 0)
     {
       /* We return COMPLETED_UNHANDLED here so that the last key press
@@ -65,6 +66,7 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
        * take care of returning HANDLED */
       if (!vim_isxdigit(context->nc))
         return COMPLETED_UNHANDLED;
+
       context->cc = context->cc * 16 + hex2nr(context->nc);
     }
     else if (context->octal)
@@ -78,10 +80,14 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
     }
     else
     {
+      
+      printf("state_insert_literal_execute - else block 2\n");
+      printf(" - VIM_ISDIGIT(context->nc): %d\n", VIM_ISDIGIT(context->nc));
       if (!VIM_ISDIGIT(context->nc))
       {
         return COMPLETED_UNHANDLED;
       }
+
       context->cc = context->cc * 10 + context->nc - '0';
     }
 

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -26,7 +26,7 @@ void *state_insert_literal_initialize(int *ret)
   insertLiteral_T *context = (insertLiteral_T *)alloc(sizeof(insertLiteral_T));
   context->hex = FALSE;
   context->octal = FALSE;
-  context->unicode = FALSE;
+  context->unicode = 0;
 
   ++no_mapping;
 
@@ -54,7 +54,7 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   }
   else if (context->nc == 'u' || context->nc == 'U')
   {
-    context->unicode = TRUE;
+    context->unicode = context->nc;
   }
   else
   {

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -40,7 +40,6 @@ void *state_insert_literal_initialize(int *ret)
 
 executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
-  printf("state_insert_literal_execute - c: |%d|\n", nc);
   insertLiteral_T *context = (insertLiteral_T *)ctx;
   context->nc = nc;
 
@@ -58,7 +57,6 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   }
   else
   {
-    printf("state_insert_literal_execute - else block 1\n");
     if (context->hex || context->unicode != 0)
     {
       /* We return COMPLETED_UNHANDLED here so that the last key press
@@ -81,9 +79,6 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
     }
     else
     {
-
-      printf("state_insert_literal_execute - else block 2\n");
-      printf(" - VIM_ISDIGIT(context->nc): %d\n", VIM_ISDIGIT(context->nc));
       if (!VIM_ISDIGIT(context->nc))
       {
         return COMPLETED_UNHANDLED;
@@ -114,11 +109,9 @@ executionStatus_T state_insert_literal_execute(void *ctx, int nc)
   }
   else if (context->i >= 3) /* decimal or octal: up to three chars */
   {
-    printf("state_insert_literal_execute - leaving after 3 decimal / octal chars\n");
     return COMPLETED_UNHANDLED;
   }
 
-  printf("state_insert_literal_execute - returning HANDLED\n");
   return HANDLED;
 }
 
@@ -140,7 +133,6 @@ void state_insert_literal_cleanup(void *ctx)
     }
   }
 
-  printf("state_insert_literal_cleanup: |%d|\n", context->cc);
   *(context->ret) = context->cc;
 
   --no_mapping;

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -37,7 +37,6 @@ void *state_insert_literal_initialize(int *ret)
   return context;
 }
 
-
 executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
   insertLiteral_T *context = (insertLiteral_T *)ctx;

--- a/src/state_insert_literal.c
+++ b/src/state_insert_literal.c
@@ -20,7 +20,7 @@ typedef struct
   int *ret;
 } insertLiteral_T;
 
-insertLiteral_T *state_insert_literal_initialize(int *ret)
+void *state_insert_literal_initialize(int *ret)
 {
 
   insertLiteral_T *context = (insertLiteral_T *)alloc(sizeof(insertLiteral_T));
@@ -37,8 +37,9 @@ insertLiteral_T *state_insert_literal_initialize(int *ret)
   return context;
 }
 
-executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
+executionStatus_T state_insert_literal_execute(void *ctx, int nc)
 {
+  insertLiteral_T *context = (insertLiteral_T *)ctx;
   context->nc = nc;
 
   if (context->nc == 'x' || context->nc == 'X')
@@ -74,7 +75,7 @@ executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
     {
       if (!VIM_ISDIGIT(context->nc))
       {
-        return COMPLETED;
+        return COMPLETED_UNHANDLED;
       }
       context->cc = context->cc * 10 + context->nc - '0';
     }
@@ -107,22 +108,25 @@ executionStatus_T state_insert_literal_execute(insertLiteral_T *context, int nc)
   return HANDLED;
 }
 
-void state_insert_literal_cleanup(insertLiteral_T *context)
+void state_insert_literal_cleanup(void *ctx)
 {
+  insertLiteral_T *context = (insertLiteral_T *)ctx;
 
   if (context->i == 0) /* no number entered */
   {
     if (context->nc == K_ZERO) /* NUL is stored as NL */
     {
-context->cc = '\n';
-context->nc = 0;
-    } else {
-    context->cc = context->nc;
-    context->nc = 0;
+      context->cc = '\n';
+      context->nc = 0;
+    }
+    else
+    {
+      context->cc = context->nc;
+      context->nc = 0;
     }
   }
 
-   *(context->ret) = context->cc;
+  *(context->ret) = context->cc;
 
   --no_mapping;
   vim_free(context);

--- a/src/state_machine.c
+++ b/src/state_machine.c
@@ -41,6 +41,11 @@ void sm_push_insert(int cmdchar, int startln, long count)
           state_edit_execute, state_edit_cleanup);
 }
 
+void sm_push_insert_literal(int *ret)
+{
+  sm_push(INSERT, state_insert_literal_initialize(ret), state_insert_literal_execute, state_insert_literal_cleanup);
+}
+
 void sm_push_cmdline(int cmdchar, long count, int indent)
 {
   sm_push(CMDLINE, state_cmdline_initialize(cmdchar, count, indent),


### PR DESCRIPTION
__Issue:__ `<C-v>` enters a mode where you can insert a literal (by typing in the actual ASCII/Unicode value). 

__Defect:__ This entered a blocking input state, causing a hang.

__Fix:__ Refactor the get-literal logic into a state machine, and use the state machine instead of blocking input.

This is the root cause of https://github.com/onivim/oni2/issues/355