### PR TITLE
Feature: unhandledEscapeCallback

### DIFF
--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -3,7 +3,8 @@
 
 static int unhandledEscapeCount = 0;
 
-void onUnhandledEscape(void) {
+void onUnhandledEscape(void)
+{
   unhandledEscapeCount++;
 }
 
@@ -88,7 +89,7 @@ MU_TEST_SUITE(test_suite)
 int main(int argc, char **argv)
 {
   vimInit(argc, argv);
-  
+
   vimSetUnhandledEscapeCallback(&onUnhandledEscape);
 
   win_setwidth(5);

--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -63,7 +63,6 @@ MU_TEST(test_arrow_keys_normal)
   mu_check(vimCursorGetColumn() == 0);
 }
 
-<<<<<<< HEAD
 MU_TEST(test_unhandled_escape)
 {
   // Should get unhandled escape...

--- a/src/globals.h
+++ b/src/globals.h
@@ -52,6 +52,7 @@ EXTERN MessageCallback messageCallback INIT(= NULL);
 EXTERN WindowSplitCallback windowSplitCallback INIT(= NULL);
 EXTERN WindowMovementCallback windowMovementCallback INIT(= NULL);
 EXTERN QuitCallback quitCallback INIT(= NULL);
+EXTERN UnhandledEscapeCallback unhandledEscapeCallback INIT(= NULL);
 
 /*
  * Globals for managing the state machine

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -76,7 +76,7 @@ void vimSetQuitCallback(QuitCallback f)
   quitCallback = f;
 }
 
-void vimSetUnhandledEscapeCallback(UnhandledEscapeCallback callback) 
+void vimSetUnhandledEscapeCallback(UnhandledEscapeCallback callback)
 {
   unhandledEscapeCallback = callback;
 }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -76,6 +76,11 @@ void vimSetQuitCallback(QuitCallback f)
   quitCallback = f;
 }
 
+void vimSetUnhandledEscapeCallback(UnhandledEscapeCallback callback) 
+{
+  unhandledEscapeCallback = callback;
+}
+
 char_u vimCommandLineGetType(void) { return ccline.cmdfirstc; }
 
 char_u *vimCommandLineGetText(void) { return ccline.cmdbuff; }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -86,7 +86,6 @@ void vimSetMessageCallback(MessageCallback messageCallback);
  **/
 
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
-void vimSetQuitCallback(QuitCallback callback);
 
 /*
  * vimSetQuitCallback
@@ -99,6 +98,17 @@ void vimSetQuitCallback(QuitCallback callback);
  * - `force`: a boolean if the command was forced (ie, if `q!` was used)
  */
 void vimSetQuitCallback(QuitCallback callback);
+
+/*
+ * vimSetUnhandledEscapeCallback
+ *
+ * Called when <esc> is pressed in normal mode, but there is no
+ * pending operator or action.
+ *
+ * This is intended for UI's to pick up and handle (for example,
+ * to clear messages or alerts).
+ */
+void vimSetUnhandledEscapeCallback(UnhandledEscapeCallback callback);
 
 /***
  * Options

--- a/src/normal.c
+++ b/src/normal.c
@@ -7182,8 +7182,10 @@ static void nv_esc(cmdarg_T *cap)
     curwin->w_set_curswant = TRUE;
     redraw_curbuf_later(INVERTED);
   }
-  else if (no_reason) {
-    if (unhandledEscapeCallback != NULL) {
+  else if (no_reason)
+  {
+    if (unhandledEscapeCallback != NULL)
+    {
       unhandledEscapeCallback();
     }
   }

--- a/src/normal.c
+++ b/src/normal.c
@@ -7182,8 +7182,11 @@ static void nv_esc(cmdarg_T *cap)
     curwin->w_set_curswant = TRUE;
     redraw_curbuf_later(INVERTED);
   }
-  else if (no_reason)
-    vim_beep(BO_ESC);
+  else if (no_reason) {
+    if (unhandledEscapeCallback != NULL) {
+      unhandledEscapeCallback();
+    }
+  }
   clearop(cap->oap);
 
   /* A CTRL-C is often used at the start of a menu.  When 'insertmode' is

--- a/src/structs.h
+++ b/src/structs.h
@@ -60,6 +60,7 @@ typedef enum
 
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);
 typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count);
+typedef void (*UnhandledEscapeCallback)(void);
 
 typedef struct
 {


### PR DESCRIPTION
This adds a callback for when the user presses <ESC> but no action is triggered (for example, in normal mode without an operator pending). This gives our UI layer a chance to execute some extra actions (like clear messages)