### PR TITLE
Remove -Wno-unknown-warning flag

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1313,7 +1313,7 @@ NO_ATTR=
 PROTO_FLAGS = -d -E"$(CPP)" $(NO_ATTR)
 
 
-WARN_FLAGS = -Wall -Wno-pointer-sign -Wno-cpp -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
+WARN_FLAGS = -Wall -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
 
 ################################################
 ##   no changes required below this line      ##

--- a/src/Makefile
+++ b/src/Makefile
@@ -1313,7 +1313,7 @@ NO_ATTR=
 PROTO_FLAGS = -d -E"$(CPP)" $(NO_ATTR)
 
 
-WARN_FLAGS = -Wall -Wno-unknown-warning-option -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
+WARN_FLAGS = -Wall -Wno-unknown-warning-option -Wno-cpp -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
 
 ################################################
 ##   no changes required below this line      ##

--- a/src/Makefile
+++ b/src/Makefile
@@ -1313,7 +1313,7 @@ NO_ATTR=
 PROTO_FLAGS = -d -E"$(CPP)" $(NO_ATTR)
 
 
-WARN_FLAGS = -Wall -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
+WARN_FLAGS = -Wall -Wno-unknown-warning-option -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Werror
 
 ################################################
 ##   no changes required below this line      ##


### PR DESCRIPTION
From onivim/oni2#435 - the `-Wno-cpp` option is problematic for OSX 10.12, but needed for other environments.