### PR TITLE
Window Splits: Hook up additional window split movements

### DIFF
--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -72,25 +72,43 @@ MU_TEST(test_win_movements)
   printf("Entering <c-j>\n");
   vimInput("<c-j>");
 
-  mu_check(lastMovement == ONE_DOWN);
+  mu_check(lastMovement == CURSOR_DOWN);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("k");
 
-  mu_check(lastMovement == ONE_UP);
+  mu_check(lastMovement == CURSOR_UP);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("h");
 
-  mu_check(lastMovement == ONE_LEFT);
+  mu_check(lastMovement == CURSOR_LEFT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("l");
 
-  mu_check(lastMovement == ONE_RIGHT);
+  mu_check(lastMovement == CURSOR_RIGHT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>");
+  vimInput("t");
+
+  mu_check(lastMovement == CURSOR_TOP_LEFT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>");
+  vimInput("b");
+
+  mu_check(lastMovement == CURSOR_BOTTOM_RIGHT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>");
+  vimInput("p");
+
+  mu_check(lastMovement == CURSOR_PREVIOUS);
   mu_check(lastMovementCount == 1);
 }
 
@@ -125,6 +143,86 @@ MU_TEST(test_win_move_count_before_and_after)
   mu_check(lastMovementCount == 35);
 }
 
+MU_TEST(test_move_commands)
+{
+  vimInput("<c-w>")
+  vimInput("H")
+  mu_check(lastMovement == MOVE_FULL_LEFT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>")
+  vimInput("L")
+  
+  mu_check(lastMovement == MOVE_FULL_RIGHT);
+  mu_check(lastMovementCount == 1);
+
+  vimInput("<c-w>")
+  vimInput("K")
+  
+  mu_check(lastMovement == MOVE_FULL_UP);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>")
+  vimInput("J")
+  
+  mu_check(lastMovement == MOVE_FULL_DOWN);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>")
+  vimInput("r")
+  
+  mu_check(lastMovement == MOVE_ROTATE_DOWNWARDS);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>")
+  vimInput("R")
+  
+  mu_check(lastMovement == MOVE_ROTATE_UPWARDS);
+  mu_check(lastMovementCount == 1);
+}
+
+MU_TEST(test_size_commands)
+{
+  vimInput("<c-w>")
+  vimInput("=")
+  mu_check(lastMovement == SIZE_EQUAL_HEIGHT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("<c-w>")
+  vimInput("+")
+  
+  mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("5")
+  vimInput("<c-w>")
+  vimInput("+")
+  
+  mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
+  mu_check(lastMovementCount == 5);
+  
+  vimInput("1")
+  vimInput("2")
+  vimInput("<c-w>")
+  vimInput("-")
+  
+  mu_check(lastMovement == SIZE_DECREASE_HEIGHT);
+  mu_check(lastMovementCount == 2);
+  
+  vimInput("<c-w>")
+  vimInput("<")
+  
+  mu_check(lastMovement == SIZE_DECREASE_WIDTH);
+  mu_check(lastMovementCount == 1);
+  
+  vimInput("2")
+  vimInput("<c-w>")
+  vimInput(">")
+  
+  mu_check(lastMovement == SIZE_INCREASE_WIDTH);
+  mu_check(lastMovementCount == 2);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -136,6 +234,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_win_move_count_before);
   MU_RUN_TEST(test_win_move_count_after);
   MU_RUN_TEST(test_win_move_count_before_and_after);
+  MU_RUN_TEST(test_move_commands);
+  MU_RUN_TEST(test_size_commands);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -146,38 +146,38 @@ MU_TEST(test_win_move_count_before_and_after)
 MU_TEST(test_move_commands)
 {
   vimInput("<c-w>");
-      vimInput("H");
-          mu_check(lastMovement == WIN_MOVE_FULL_LEFT);
+  vimInput("H");
+  mu_check(lastMovement == WIN_MOVE_FULL_LEFT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
-      vimInput("L");
+  vimInput("L");
 
-          mu_check(lastMovement == WIN_MOVE_FULL_RIGHT);
+  mu_check(lastMovement == WIN_MOVE_FULL_RIGHT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
-      vimInput("K");
+  vimInput("K");
 
-          mu_check(lastMovement == WIN_MOVE_FULL_UP);
+  mu_check(lastMovement == WIN_MOVE_FULL_UP);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
-      vimInput("J");
+  vimInput("J");
 
-          mu_check(lastMovement == WIN_MOVE_FULL_DOWN);
+  mu_check(lastMovement == WIN_MOVE_FULL_DOWN);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
-      vimInput("r");
+  vimInput("r");
 
-          mu_check(lastMovement == WIN_MOVE_ROTATE_DOWNWARDS);
+  mu_check(lastMovement == WIN_MOVE_ROTATE_DOWNWARDS);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
-      vimInput("R");
+  vimInput("R");
 
-          mu_check(lastMovement == WIN_MOVE_ROTATE_UPWARDS);
+  mu_check(lastMovement == WIN_MOVE_ROTATE_UPWARDS);
   mu_check(lastMovementCount == 1);
 }
 

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -92,19 +92,19 @@ MU_TEST(test_win_movements)
 
   mu_check(lastMovement == CURSOR_RIGHT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>");
   vimInput("t");
 
   mu_check(lastMovement == CURSOR_TOP_LEFT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>");
   vimInput("b");
 
   mu_check(lastMovement == CURSOR_BOTTOM_RIGHT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>");
   vimInput("p");
 
@@ -146,80 +146,80 @@ MU_TEST(test_win_move_count_before_and_after)
 MU_TEST(test_move_commands)
 {
   vimInput("<c-w>")
-  vimInput("H")
-  mu_check(lastMovement == MOVE_FULL_LEFT);
-  mu_check(lastMovementCount == 1);
-  
-  vimInput("<c-w>")
-  vimInput("L")
-  
-  mu_check(lastMovement == MOVE_FULL_RIGHT);
+      vimInput("H")
+          mu_check(lastMovement == MOVE_FULL_LEFT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>")
-  vimInput("K")
-  
-  mu_check(lastMovement == MOVE_FULL_UP);
+      vimInput("L")
+
+          mu_check(lastMovement == MOVE_FULL_RIGHT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>")
-  vimInput("J")
-  
-  mu_check(lastMovement == MOVE_FULL_DOWN);
+      vimInput("K")
+
+          mu_check(lastMovement == MOVE_FULL_UP);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>")
-  vimInput("r")
-  
-  mu_check(lastMovement == MOVE_ROTATE_DOWNWARDS);
+      vimInput("J")
+
+          mu_check(lastMovement == MOVE_FULL_DOWN);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>")
-  vimInput("R")
-  
-  mu_check(lastMovement == MOVE_ROTATE_UPWARDS);
+      vimInput("r")
+
+          mu_check(lastMovement == MOVE_ROTATE_DOWNWARDS);
+  mu_check(lastMovementCount == 1);
+
+  vimInput("<c-w>")
+      vimInput("R")
+
+          mu_check(lastMovement == MOVE_ROTATE_UPWARDS);
   mu_check(lastMovementCount == 1);
 }
 
 MU_TEST(test_size_commands)
 {
   vimInput("<c-w>")
-  vimInput("=")
-  mu_check(lastMovement == SIZE_EQUAL_HEIGHT);
+      vimInput("=")
+          mu_check(lastMovement == SIZE_EQUAL_HEIGHT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("<c-w>")
-  vimInput("+")
-  
-  mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
+      vimInput("+")
+
+          mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("5")
-  vimInput("<c-w>")
-  vimInput("+")
-  
-  mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
+      vimInput("<c-w>")
+          vimInput("+")
+
+              mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
   mu_check(lastMovementCount == 5);
-  
+
   vimInput("1")
-  vimInput("2")
-  vimInput("<c-w>")
-  vimInput("-")
-  
-  mu_check(lastMovement == SIZE_DECREASE_HEIGHT);
+      vimInput("2")
+          vimInput("<c-w>")
+              vimInput("-")
+
+                  mu_check(lastMovement == SIZE_DECREASE_HEIGHT);
   mu_check(lastMovementCount == 2);
-  
+
   vimInput("<c-w>")
-  vimInput("<")
-  
-  mu_check(lastMovement == SIZE_DECREASE_WIDTH);
+      vimInput("<")
+
+          mu_check(lastMovement == SIZE_DECREASE_WIDTH);
   mu_check(lastMovementCount == 1);
-  
+
   vimInput("2")
-  vimInput("<c-w>")
-  vimInput(">")
-  
-  mu_check(lastMovement == SIZE_INCREASE_WIDTH);
+      vimInput("<c-w>")
+          vimInput(">")
+
+              mu_check(lastMovement == SIZE_INCREASE_WIDTH);
   mu_check(lastMovementCount == 2);
 }
 

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -72,43 +72,43 @@ MU_TEST(test_win_movements)
   printf("Entering <c-j>\n");
   vimInput("<c-j>");
 
-  mu_check(lastMovement == CURSOR_DOWN);
+  mu_check(lastMovement == WIN_CURSOR_DOWN);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("k");
 
-  mu_check(lastMovement == CURSOR_UP);
+  mu_check(lastMovement == WIN_CURSOR_UP);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("h");
 
-  mu_check(lastMovement == CURSOR_LEFT);
+  mu_check(lastMovement == WIN_CURSOR_LEFT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("l");
 
-  mu_check(lastMovement == CURSOR_RIGHT);
+  mu_check(lastMovement == WIN_CURSOR_RIGHT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("t");
 
-  mu_check(lastMovement == CURSOR_TOP_LEFT);
+  mu_check(lastMovement == WIN_CURSOR_TOP_LEFT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("b");
 
-  mu_check(lastMovement == CURSOR_BOTTOM_RIGHT);
+  mu_check(lastMovement == WIN_CURSOR_BOTTOM_RIGHT);
   mu_check(lastMovementCount == 1);
 
   vimInput("<c-w>");
   vimInput("p");
 
-  mu_check(lastMovement == CURSOR_PREVIOUS);
+  mu_check(lastMovement == WIN_CURSOR_PREVIOUS);
   mu_check(lastMovementCount == 1);
 }
 
@@ -118,7 +118,7 @@ MU_TEST(test_win_move_count_before)
   vimInput("<c-w>");
   vimInput("k");
 
-  mu_check(lastMovement == ONE_UP);
+  mu_check(lastMovement == WIN_CURSOR_UP);
   mu_check(lastMovementCount == 2);
 }
 
@@ -128,7 +128,7 @@ MU_TEST(test_win_move_count_after)
   vimInput("4");
   vimInput("k");
 
-  mu_check(lastMovement == ONE_UP);
+  mu_check(lastMovement == WIN_CURSOR_UP);
   mu_check(lastMovementCount == 4);
 }
 
@@ -139,88 +139,46 @@ MU_TEST(test_win_move_count_before_and_after)
   vimInput("5");
   vimInput("k");
 
-  mu_check(lastMovement == ONE_UP);
+  mu_check(lastMovement == WIN_CURSOR_UP);
   mu_check(lastMovementCount == 35);
 }
 
 MU_TEST(test_move_commands)
 {
-  vimInput("<c-w>")
-      vimInput("H")
-          mu_check(lastMovement == MOVE_FULL_LEFT);
+  vimInput("<c-w>");
+      vimInput("H");
+          mu_check(lastMovement == WIN_MOVE_FULL_LEFT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>")
-      vimInput("L")
+  vimInput("<c-w>");
+      vimInput("L");
 
-          mu_check(lastMovement == MOVE_FULL_RIGHT);
+          mu_check(lastMovement == WIN_MOVE_FULL_RIGHT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>")
-      vimInput("K")
+  vimInput("<c-w>");
+      vimInput("K");
 
-          mu_check(lastMovement == MOVE_FULL_UP);
+          mu_check(lastMovement == WIN_MOVE_FULL_UP);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>")
-      vimInput("J")
+  vimInput("<c-w>");
+      vimInput("J");
 
-          mu_check(lastMovement == MOVE_FULL_DOWN);
+          mu_check(lastMovement == WIN_MOVE_FULL_DOWN);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>")
-      vimInput("r")
+  vimInput("<c-w>");
+      vimInput("r");
 
-          mu_check(lastMovement == MOVE_ROTATE_DOWNWARDS);
+          mu_check(lastMovement == WIN_MOVE_ROTATE_DOWNWARDS);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>")
-      vimInput("R")
+  vimInput("<c-w>");
+      vimInput("R");
 
-          mu_check(lastMovement == MOVE_ROTATE_UPWARDS);
+          mu_check(lastMovement == WIN_MOVE_ROTATE_UPWARDS);
   mu_check(lastMovementCount == 1);
-}
-
-MU_TEST(test_size_commands)
-{
-  vimInput("<c-w>")
-      vimInput("=")
-          mu_check(lastMovement == SIZE_EQUAL_HEIGHT);
-  mu_check(lastMovementCount == 1);
-
-  vimInput("<c-w>")
-      vimInput("+")
-
-          mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
-  mu_check(lastMovementCount == 1);
-
-  vimInput("5")
-      vimInput("<c-w>")
-          vimInput("+")
-
-              mu_check(lastMovement == SIZE_INCREASE_HEIGHT);
-  mu_check(lastMovementCount == 5);
-
-  vimInput("1")
-      vimInput("2")
-          vimInput("<c-w>")
-              vimInput("-")
-
-                  mu_check(lastMovement == SIZE_DECREASE_HEIGHT);
-  mu_check(lastMovementCount == 2);
-
-  vimInput("<c-w>")
-      vimInput("<")
-
-          mu_check(lastMovement == SIZE_DECREASE_WIDTH);
-  mu_check(lastMovementCount == 1);
-
-  vimInput("2")
-      vimInput("<c-w>")
-          vimInput(">")
-
-              mu_check(lastMovement == SIZE_INCREASE_WIDTH);
-  mu_check(lastMovementCount == 2);
 }
 
 MU_TEST_SUITE(test_suite)
@@ -235,7 +193,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_win_move_count_after);
   MU_RUN_TEST(test_win_move_count_before_and_after);
   MU_RUN_TEST(test_move_commands);
-  MU_RUN_TEST(test_size_commands);
 }
 
 int main(int argc, char **argv)

--- a/src/structs.h
+++ b/src/structs.h
@@ -46,24 +46,19 @@ typedef enum
 
 typedef enum
 {
-  CURSOR_LEFT,           // <C-w>h
-  CURSOR_RIGHT,          // <C-w>l
-  CURSOR_UP,             // <C-w>k
-  CURSOR_DOWN,           // <C-w>j
-  MOVE_FULL_LEFT,        // <C-w>H
-  MOVE_FULL_RIGHT,       // <C-w>L
-  MOVE_FULL_UP,          // <C-w>K
-  MOVE_FULL_DOWN,        // <C-w>J
-  CURSOR_TOP_LEFT,       // <C-w>t
-  CURSOR_BOTTOM_RIGHT,   // <C-w>b
-  CURSOR_PREVIOUS,       // <C-w>p
-  MOVE_ROTATE_DOWNWARDS, // <C-w>r
-  MOVE_ROTATE_UPWARDS,   // <C-w>R
-  SIZE_EQUAL_HEIGHT,     // <C-w> =
-  SIZE_INCREASE_HEIGHT,  // <C-w> +
-  SIZE_DECREASE_HEIGHT,  // <C-w> -
-  SIZE_INCREASE_WIDTH,   // <C-w> >
-  SIZE_DECREASE_WIDTH,   // <C-w> <
+  WIN_CURSOR_LEFT,           // <C-w>h
+  WIN_CURSOR_RIGHT,          // <C-w>l
+  WIN_CURSOR_UP,             // <C-w>k
+  WIN_CURSOR_DOWN,           // <C-w>j
+  WIN_MOVE_FULL_LEFT,        // <C-w>H
+  WIN_MOVE_FULL_RIGHT,       // <C-w>L
+  WIN_MOVE_FULL_UP,          // <C-w>K
+  WIN_MOVE_FULL_DOWN,        // <C-w>J
+  WIN_CURSOR_TOP_LEFT,       // <C-w>t
+  WIN_CURSOR_BOTTOM_RIGHT,   // <C-w>b
+  WIN_CURSOR_PREVIOUS,       // <C-w>p
+  WIN_MOVE_ROTATE_DOWNWARDS, // <C-w>r
+  WIN_MOVE_ROTATE_UPWARDS,   // <C-w>R
 } windowMovement_T;
 
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);

--- a/src/structs.h
+++ b/src/structs.h
@@ -46,16 +46,24 @@ typedef enum
 
 typedef enum
 {
-  ONE_LEFT,
-  ONE_RIGHT,
-  ONE_UP,
-  ONE_DOWN,
-  FULL_LEFT,
-  FULL_RIGHT,
-  FULL_UP,
-  FULL_DOWN,
-  TOP_LEFT,
-  BOTTOM_RIGHT
+  CURSOR_LEFT, // <C-w>h
+  CURSOR_RIGHT, // <C-w>l
+  CURSOR_UP, // <C-w>k
+  CURSOR_DOWN, // <C-w>j
+  MOVE_FULL_LEFT, // <C-w>H
+  MOVE_FULL_RIGHT, // <C-w>L
+  MOVE_FULL_UP, // <C-w>K
+  MOVE_FULL_DOWN, // <C-w>J
+  CURSOR_TOP_LEFT, // <C-w>t
+  CURSOR_BOTTOM_RIGHT, // <C-w>b
+  CURSOR_PREVIOUS, // <C-w>p
+  MOVE_ROTATE_DOWNWARDS, // <C-w>r
+  MOVE_ROTATE_UPWARDS, // <C-w>R
+  SIZE_EQUAL_HEIGHT, // <C-w> =
+  SIZE_INCREASE_HEIGHT, // <C-w> +
+  SIZE_DECREASE_HEIGHT, // <C-w> -
+  SIZE_INCREASE_WIDTH, // <C-w> >
+  SIZE_DECREASE_WIDTH, // <C-w> <
 } windowMovement_T;
 
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);

--- a/src/structs.h
+++ b/src/structs.h
@@ -46,24 +46,24 @@ typedef enum
 
 typedef enum
 {
-  CURSOR_LEFT, // <C-w>h
-  CURSOR_RIGHT, // <C-w>l
-  CURSOR_UP, // <C-w>k
-  CURSOR_DOWN, // <C-w>j
-  MOVE_FULL_LEFT, // <C-w>H
-  MOVE_FULL_RIGHT, // <C-w>L
-  MOVE_FULL_UP, // <C-w>K
-  MOVE_FULL_DOWN, // <C-w>J
-  CURSOR_TOP_LEFT, // <C-w>t
-  CURSOR_BOTTOM_RIGHT, // <C-w>b
-  CURSOR_PREVIOUS, // <C-w>p
+  CURSOR_LEFT,           // <C-w>h
+  CURSOR_RIGHT,          // <C-w>l
+  CURSOR_UP,             // <C-w>k
+  CURSOR_DOWN,           // <C-w>j
+  MOVE_FULL_LEFT,        // <C-w>H
+  MOVE_FULL_RIGHT,       // <C-w>L
+  MOVE_FULL_UP,          // <C-w>K
+  MOVE_FULL_DOWN,        // <C-w>J
+  CURSOR_TOP_LEFT,       // <C-w>t
+  CURSOR_BOTTOM_RIGHT,   // <C-w>b
+  CURSOR_PREVIOUS,       // <C-w>p
   MOVE_ROTATE_DOWNWARDS, // <C-w>r
-  MOVE_ROTATE_UPWARDS, // <C-w>R
-  SIZE_EQUAL_HEIGHT, // <C-w> =
-  SIZE_INCREASE_HEIGHT, // <C-w> +
-  SIZE_DECREASE_HEIGHT, // <C-w> -
-  SIZE_INCREASE_WIDTH, // <C-w> >
-  SIZE_DECREASE_WIDTH, // <C-w> <
+  MOVE_ROTATE_UPWARDS,   // <C-w>R
+  SIZE_EQUAL_HEIGHT,     // <C-w> =
+  SIZE_INCREASE_HEIGHT,  // <C-w> +
+  SIZE_DECREASE_HEIGHT,  // <C-w> -
+  SIZE_INCREASE_WIDTH,   // <C-w> >
+  SIZE_DECREASE_WIDTH,   // <C-w> <
 } windowMovement_T;
 
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);

--- a/src/window.c
+++ b/src/window.c
@@ -97,14 +97,14 @@ void do_window(
   case 'j':
   case K_DOWN:
   case Ctrl_J:
-    windowMovementCallback(ONE_DOWN, Prenum1);
+    windowMovementCallback(WIN_CURSOR_DOWN, Prenum1);
     break;
 
     /* cursor to window above */
   case 'k':
   case K_UP:
   case Ctrl_K:
-    windowMovementCallback(ONE_UP, Prenum1);
+    windowMovementCallback(WIN_CURSOR_UP, Prenum1);
     break;
 
     /* cursor to left window */
@@ -112,15 +112,53 @@ void do_window(
   case K_LEFT:
   case Ctrl_H:
   case K_BS:
-    windowMovementCallback(ONE_LEFT, Prenum1);
+    windowMovementCallback(WIN_CURSOR_LEFT, Prenum1);
     break;
 
     /* cursor to right window */
   case 'l':
   case K_RIGHT:
   case Ctrl_L:
-    windowMovementCallback(ONE_RIGHT, Prenum1);
+    windowMovementCallback(WIN_CURSOR_RIGHT, Prenum1);
     break;
+
+  case 'L':
+    windowMovementCallback(WIN_MOVE_FULL_RIGHT, Prenum1);
+    break;
+  case 'H':
+    windowMovementCallback(WIN_MOVE_FULL_LEFT, Prenum1);
+    break;
+  case 'K':
+    windowMovementCallback(WIN_MOVE_FULL_UP, Prenum1);
+    break;
+
+  case 'J':
+    windowMovementCallback(WIN_MOVE_FULL_DOWN, Prenum1);
+    break;
+  
+  case 't':
+  case Ctrl_T:
+    windowMovementCallback(WIN_CURSOR_TOP_LEFT, Prenum1);
+    break;
+  
+  case 'b':
+  case Ctrl_B:
+    windowMovementCallback(WIN_CURSOR_BOTTOM_RIGHT, Prenum1);
+    break;
+  
+  case 'p':
+  case Ctrl_P:
+    windowMovementCallback(WIN_CURSOR_PREVIOUS, Prenum1);
+    break;
+  
+  case 'r':
+  case Ctrl_R:
+    windowMovementCallback(WIN_MOVE_ROTATE_DOWNWARDS, Prenum1);
+    break;
+  case 'R':
+    windowMovementCallback(WIN_MOVE_ROTATE_UPWARDS, Prenum1);
+    break;
+
   default:
     return;
   }

--- a/src/window.c
+++ b/src/window.c
@@ -135,22 +135,22 @@ void do_window(
   case 'J':
     windowMovementCallback(WIN_MOVE_FULL_DOWN, Prenum1);
     break;
-  
+
   case 't':
   case Ctrl_T:
     windowMovementCallback(WIN_CURSOR_TOP_LEFT, Prenum1);
     break;
-  
+
   case 'b':
   case Ctrl_B:
     windowMovementCallback(WIN_CURSOR_BOTTOM_RIGHT, Prenum1);
     break;
-  
+
   case 'p':
   case Ctrl_P:
     windowMovementCallback(WIN_CURSOR_PREVIOUS, Prenum1);
     break;
-  
+
   case 'r':
   case Ctrl_R:
     windowMovementCallback(WIN_MOVE_ROTATE_DOWNWARDS, Prenum1);


### PR DESCRIPTION
This adds 'externalization' of the following window split movements:
- `<C-w>r`
- `<C-w>R`
- `<C-w>b`
- `<C-w>t`

It also changes the naming convention for the window splits enum - `WIN_CURSOR` means the cursor moves, but window positions are unchanged, whereas `WIN_MOVE` means the actual window moves to a new location.