### PR TITLE
Window Splits: Externalize <c-w>v and <c-w>s

### DIFF
--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -61,10 +61,21 @@ MU_TEST(test_vsplit_ctrl_w)
   vimBufferOpen("collateral/testfile.txt", 1, 0);
 
   vimInput("<c-w>");
-  vimInput("<c-v>");
-  
-  mu_check(strcmp(lastFilename, "collateral/testfile.txt") == 0);
+  vimInput("v");
+
   mu_check(lastSplitType == VERTICAL_SPLIT);
+  mu_check(strstr(lastFilename, "testfile.txt") != NULL);
+}
+
+MU_TEST(test_hsplit_ctrl_w)
+{
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  vimInput("<c-w>");
+  vimInput("s");
+
+  mu_check(lastSplitType == HORIZONTAL_SPLIT);
+  mu_check(strstr(lastFilename, "testfile.txt") != NULL);
 }
 
 MU_TEST(test_tabnew)
@@ -141,8 +152,9 @@ MU_TEST_SUITE(test_suite)
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_vsplit);
-  MU_RUN_TEST(test_vsplit_ctrl_w);
   MU_RUN_TEST(test_hsplit);
+  MU_RUN_TEST(test_vsplit_ctrl_w);
+  MU_RUN_TEST(test_hsplit_ctrl_w);
   MU_RUN_TEST(test_tabnew);
   MU_RUN_TEST(test_win_movements);
   MU_RUN_TEST(test_win_move_count_before);

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -56,6 +56,17 @@ MU_TEST(test_hsplit)
   mu_check(lastSplitType == HORIZONTAL_SPLIT);
 }
 
+MU_TEST(test_vsplit_ctrl_w)
+{
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  vimInput("<c-w>");
+  vimInput("<c-v>");
+  
+  mu_check(strcmp(lastFilename, "collateral/testfile.txt") == 0);
+  mu_check(lastSplitType == VERTICAL_SPLIT);
+}
+
 MU_TEST(test_tabnew)
 {
   vimExecute("tabnew test-tabnew-file.txt");
@@ -130,6 +141,7 @@ MU_TEST_SUITE(test_suite)
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_vsplit);
+  MU_RUN_TEST(test_vsplit_ctrl_w);
   MU_RUN_TEST(test_hsplit);
   MU_RUN_TEST(test_tabnew);
   MU_RUN_TEST(test_win_movements);

--- a/src/window.c
+++ b/src/window.c
@@ -86,11 +86,29 @@ void do_window(
 #endif
   char_u cbuf[40];
 
-  if (windowMovementCallback == NULL)
-    return;
-
   Prenum1 = Prenum == 0 ? 1 : Prenum;
 
+  /* Split shortcuts */
+  switch (nchar)
+  {
+  case 's':
+    if (windowSplitCallback != NULL)
+    {
+      windowSplitCallback(HORIZONTAL_SPLIT, curbuf->b_ffname);
+    }
+    return;
+  case 'v':
+    if (windowSplitCallback != NULL)
+    {
+      windowSplitCallback(VERTICAL_SPLIT, curbuf->b_ffname);
+    }
+    return;
+  default:
+    break;
+  }
+
+  if (windowMovementCallback == NULL)
+    return;
   switch (nchar)
   {
     /* cursor to window below */


### PR DESCRIPTION
This change forwards the `<c-w>v` (vertical split) and `<c-w>s` (horizontal split) gestures to the consumer to handle, like the `:sp` and `:vsp` commands.