### PR TITLE
Bugfix: vimBufferGetModified is not always up-to-date

### DIFF
--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -19,6 +19,9 @@ void onBufferUpdate(bufferUpdate_T update)
 
 void test_setup(void)
 {
+  vimInput("<esc>");
+  vimInput("<esc>");
+
   vimExecute("e!");
 
   vimInput("g");
@@ -108,6 +111,39 @@ MU_TEST(test_insert)
   mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
 }
 
+MU_TEST(test_modified)
+{
+  vimInput("i");
+  vimInput("a");
+
+  mu_check(vimBufferGetModified(curbuf) == TRUE);
+}
+
+MU_TEST(test_reset_modified_after_reload)
+{
+  vimInput("i");
+  vimInput("a");
+
+  vimExecute("e!");
+
+  mu_check(vimBufferGetModified(curbuf) == FALSE);
+}
+
+MU_TEST(test_reset_modified_after_undo)
+{
+  vimExecute("e!");
+  mu_check(vimBufferGetModified(curbuf) == FALSE);
+
+  vimInput("O");
+  vimInput("a");
+  printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "a") == 0);
+
+  vimInput("<esc>");
+  vimInput("u");
+  mu_check(vimBufferGetModified(curbuf) == FALSE);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -118,6 +154,9 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_delete_line);
   MU_RUN_TEST(test_delete_multiple_lines);
   MU_RUN_TEST(test_insert);
+  MU_RUN_TEST(test_modified);
+  MU_RUN_TEST(test_reset_modified_after_reload);
+  MU_RUN_TEST(test_reset_modified_after_undo);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -142,6 +142,10 @@ MU_TEST(test_reset_modified_after_undo)
   vimInput("<esc>");
   vimInput("u");
   mu_check(vimBufferGetModified(curbuf) == FALSE);
+
+  vimInput("<c-r>");
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "a") == 0);
+  mu_check(vimBufferGetModified(curbuf) == TRUE);
 }
 
 MU_TEST_SUITE(test_suite)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -31,7 +31,7 @@ int vimBufferGetId(buf_T *buf) { return buf->b_fnum; }
 
 long vimBufferGetLastChangedTick(buf_T *buf) { return CHANGEDTICK(buf); }
 
-int vimBufferGetModified(buf_T *buf) { return buf->b_changed; }
+int vimBufferGetModified(buf_T *buf) { return bufIsChanged(buf); }
 
 char_u *vimBufferGetLine(buf_T *buf, linenr_T lnum)
 {


### PR DESCRIPTION
__Issue:__ The `vimBufferGetModified` method is not always reporting the correct value.

__Defect:__ There is additional logic in Vim besides just checking the `b_changed` buffer flag.

__Fix:__ Use the `bufIsChanged` method from `undo.c` instead, and add some test cases to validate this behavior.