### PR TITLE
Test: Add case for `<C-[>` character acting as escape

### DIFF
--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -54,7 +54,8 @@ MU_TEST(test_arrow_keys_normal)
   mu_check(vimCursorGetColumn() == 0);
 }
 
-MU_TEST(test_control_bracket) {
+MU_TEST(test_control_bracket)
+{
   vimInput("i");
 
   mu_check((vimGetMode() & INSERT) == INSERT);

--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -54,6 +54,15 @@ MU_TEST(test_arrow_keys_normal)
   mu_check(vimCursorGetColumn() == 0);
 }
 
+MU_TEST(test_control_bracket) {
+  vimInput("i");
+
+  mu_check((vimGetMode() & INSERT) == INSERT);
+
+  vimInput("<c-[>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -61,6 +70,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_arrow_keys_normal);
   MU_RUN_TEST(test_cmd_key_insert);
   MU_RUN_TEST(test_cmd_key_binding);
+  MU_RUN_TEST(test_control_bracket);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
There was a bug reported on Discord about `<C-[>` not working properly in Onivim 2. This adds a test case to validate the behavior at the libvim level.

This test case works as expected, so it seems like the bug is actually higher level (Onivim 2 isn't sending the correct keystroke to libvim in this case).