### PR TITLE
Bugfix: Registers were not being picked up correctly

### DIFF
--- a/src/apitest/registers.c
+++ b/src/apitest/registers.c
@@ -31,21 +31,21 @@ MU_TEST(test_yank_to_register)
   mu_check(strcmp(lines[0], "This is the first line of a test file") == 0);
 }
 
-MU_TEST(test_yank_to_register)
+MU_TEST(test_delete_to_register)
 {
   vimInput("\"");
-  vimInput("a");
+  vimInput("b");
 
-  vimInput("y");
-  vimInput("y");
+  vimInput("d");
+  vimInput("j");
 
   int numLines;
   char_u **lines;
-  vimRegisterGet('a', &numLines, &lines);
+  vimRegisterGet('b', &numLines, &lines);
 
-  mu_check(numLines == 1);
-  printf("LINE: %s\n", lines[0]);
-  mu_check(strcmp(lines[0], "This is the first line of a test file") == 0);
+  mu_check(numLines == 2);
+  printf("LINE: %s\n", lines[1]);
+  mu_check(strcmp(lines[1], "This is the second line of a test file") == 0);
 }
 
 MU_TEST(test_extra_yank_doesnt_reset)
@@ -74,6 +74,7 @@ MU_TEST_SUITE(test_suite)
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_yank_to_register);
+  MU_RUN_TEST(test_delete_to_register);
   MU_RUN_TEST(test_extra_yank_doesnt_reset);
 }
 

--- a/src/apitest/registers.c
+++ b/src/apitest/registers.c
@@ -1,0 +1,92 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void)
+{
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_yank_to_register)
+{
+  vimInput("\"");
+  vimInput("a");
+
+  vimInput("y");
+  vimInput("y");
+
+  int numLines;
+  char_u **lines;
+  vimRegisterGet('a', &numLines, &lines);
+
+  mu_check(numLines == 1);
+  printf("LINE: %s\n", lines[0]);
+  mu_check(strcmp(lines[0], "This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_yank_to_register)
+{
+  vimInput("\"");
+  vimInput("a");
+
+  vimInput("y");
+  vimInput("y");
+
+  int numLines;
+  char_u **lines;
+  vimRegisterGet('a', &numLines, &lines);
+
+  mu_check(numLines == 1);
+  printf("LINE: %s\n", lines[0]);
+  mu_check(strcmp(lines[0], "This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_extra_yank_doesnt_reset)
+{
+  vimInput("\"");
+  vimInput("a");
+
+  vimInput("y");
+  vimInput("y");
+
+  vimInput("j");
+  vimInput("y");
+  vimInput("y");
+
+  int numLines;
+  char_u **lines;
+  vimRegisterGet('a', &numLines, &lines);
+
+  mu_check(numLines == 1);
+  printf("LINE: %s\n", lines[0]);
+  mu_check(strcmp(lines[0], "This is the first line of a test file") == 0);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_yank_to_register);
+  MU_RUN_TEST(test_extra_yank_doesnt_reset);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/normal.c
+++ b/src/normal.c
@@ -30,7 +30,7 @@ static int restart_VIsual_select = 0;
  * This keeps track of whether or not there was a persisted
  * register from the previous operation.
  */
-static int keep_reg = 0; 
+static int keep_reg = 0;
 
 #ifdef FEAT_EVAL
 static void set_vcount_ca(cmdarg_T *cap, int *set_prevcount);
@@ -525,10 +525,11 @@ void start_normal_mode(normalCmd_T *context)
     oap->prev_opcount = 0;
     oap->prev_count0 = 0;
   }
-  
+
   /* Consume register if there is one persisted from previous operation */
-  if (keep_reg != 0) {
-    context->oap->regname = keep_reg; 
+  if (keep_reg != 0)
+  {
+    context->oap->regname = keep_reg;
     keep_reg = 0;
   }
 
@@ -613,7 +614,6 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c)
   }
 
   oparg_T *oap = context->oap;
-
 
 restart_state:
   switch (context->state)
@@ -868,7 +868,8 @@ restart_state:
     {
       finish_op = FALSE;
       /* If the register wasn't cleared, it needs to persist to next op */
-      if (context->oap->regname != 0) {
+      if (context->oap->regname != 0)
+      {
         keep_reg = context->oap->regname;
       }
       return COMPLETED;


### PR DESCRIPTION
__Issue:__ Operations with registers, like `"ayy` were not working correctly.

__Defect:__ Both `"` and `y` are considered operators. Libvim's state-machine lifecycle always resets the operator pending arguments between each operator. However, with the `"` operator (or any operator with the `KEEPREG` flag) we need to persist the register name.

__Fix:__ If the `oap->regname` is still set, which indicates `KEEPREG` was set, we'll persist it globally so the next iteration of the state machine can pick it up.