### PR TITLE
fix(bug fix): vimCursorSetPosition should update topline if necessary

### DIFF
--- a/src/apitest/cursor.c
+++ b/src/apitest/cursor.c
@@ -34,6 +34,34 @@ MU_TEST(test_set_cursor_invalid_line)
   mu_check(vimCursorGetColumn() == 4);
 }
 
+MU_TEST(test_set_cursor_offscreen_updates_topline)
+{
+  vimWindowSetTopLeft(1, 1);
+  pos_T pos;
+  pos.lnum = 90;
+  pos.col = 4;
+  vimCursorSetPosition(pos);
+
+  mu_check(vimCursorGetLine() == 90);
+  mu_check(vimCursorGetColumn() == 4);
+  printf("window topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 62);
+}
+
+MU_TEST(test_set_cursor_doesnt_move_topline)
+{
+  vimWindowSetTopLeft(71, 1);
+  pos_T pos;
+  pos.lnum = 90;
+  pos.col = 4;
+  vimCursorSetPosition(pos);
+
+  mu_check(vimCursorGetLine() == 90);
+  mu_check(vimCursorGetColumn() == 4);
+  printf("window topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 71);
+}
+
 MU_TEST(test_set_cursor_invalid_column)
 {
   pos_T pos;
@@ -52,6 +80,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_set_cursor);
   MU_RUN_TEST(test_set_cursor_invalid_line);
   MU_RUN_TEST(test_set_cursor_invalid_column);
+  MU_RUN_TEST(test_set_cursor_offscreen_updates_topline);
+  MU_RUN_TEST(test_set_cursor_doesnt_move_topline);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -112,6 +112,9 @@ void vimCursorSetPosition(pos_T pos)
   curwin->w_cursor.col = pos.col;
   /* TODO: coladd? */
   check_cursor();
+
+  // We also need to adjust the topline, potentially, if the cursor moved off-screen
+  update_topline();
 }
 
 void vimInput(char_u *input)


### PR DESCRIPTION
__Issue:__ Related to https://github.com/onivim/oni2/issues/498 - when moving the cursor, we shouldn't reset the scroll.

__Defect:__ `libvim` was not adjusting the topline in response to cursor movement

__Fix:__ Call the `update_topline` method which ensures that the cursor is in view. Add test cases to validate the case where the cursor is moved offscreen (in which case, topline should be scrolled), and in the case where the cursor is already in view - topline should not be moved