### PR TITLE
Bugfix: Additional fixes to support topline / botline

### DIFF
--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -34,6 +34,7 @@ MU_TEST(test_set_get_metrics)
   vimWindowSetHeight(101);
 
   mu_check(vimWindowGetWidth() == 100);
+  printf("HEIGHT: %d\n", vimWindowGetHeight());
   mu_check(vimWindowGetHeight() == 101);
 }
 

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -304,10 +304,10 @@ void vimWindowSetWidth(int width)
   if (width > Columns)
   {
     Columns = width;
+    screenalloc(FALSE);
   }
 
   win_new_width(curwin, width);
-  changed_window_setting();
 }
 
 void vimWindowSetHeight(int height)
@@ -315,10 +315,10 @@ void vimWindowSetHeight(int height)
   if (height > Rows)
   {
     Rows = height;
+    screenalloc(FALSE);
   }
 
   win_new_height(curwin, height);
-  changed_window_setting();
 }
 
 int vimGetMode(void) { return get_real_state(); }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -112,9 +112,8 @@ void vimCursorSetPosition(pos_T pos)
   curwin->w_cursor.col = pos.col;
   /* TODO: coladd? */
   check_cursor();
-
   // We also need to adjust the topline, potentially, if the cursor moved off-screen
-  update_topline();
+  curs_columns(TRUE);
 }
 
 void vimInput(char_u *input)
@@ -295,9 +294,9 @@ int vimWindowGetLeftColumn(void) { return curwin->w_leftcol; }
 
 void vimWindowSetTopLeft(int top, int left)
 {
-  curwin->w_topline = top;
+  set_topline(curwin, top);
   curwin->w_leftcol = left;
-  curs_columns(TRUE);
+  validate_botline();
 }
 
 void vimWindowSetWidth(int width)
@@ -308,6 +307,7 @@ void vimWindowSetWidth(int width)
   }
 
   win_new_width(curwin, width);
+  changed_window_setting();
 }
 
 void vimWindowSetHeight(int height)
@@ -318,6 +318,7 @@ void vimWindowSetHeight(int height)
   }
 
   win_new_height(curwin, height);
+  changed_window_setting();
 }
 
 int vimGetMode(void) { return get_real_state(); }

--- a/src/move.c
+++ b/src/move.c
@@ -2294,6 +2294,8 @@ void halfpage(int flag, linenr_T Prenum)
     curwin->w_p_scr = (Prenum > curwin->w_height) ? curwin->w_height : Prenum;
   n = (curwin->w_p_scr <= curwin->w_height) ? curwin->w_p_scr : curwin->w_height;
 
+  printf("N is: %d\n", n);
+
   update_topline();
   validate_botline();
   room = curwin->w_empty_rows;

--- a/src/move.c
+++ b/src/move.c
@@ -2294,8 +2294,6 @@ void halfpage(int flag, linenr_T Prenum)
     curwin->w_p_scr = (Prenum > curwin->w_height) ? curwin->w_height : Prenum;
   n = (curwin->w_p_scr <= curwin->w_height) ? curwin->w_p_scr : curwin->w_height;
 
-  printf("N is: %d\n", n);
-
   update_topline();
   validate_botline();
   room = curwin->w_empty_rows;


### PR DESCRIPTION
Investigating further, it seemed that there were cases where the `topline` would get moved unpredictably when the cursor moved (even though it _should_ be in the viewport).

It turns out that we weren't setting `w_botline`, which would cause problems in the scroll behavior when detecting whether or not the cursor was in the viewport. This validates the bottm line when we explicitly set the topline.