### PR TITLE
Bugfix: Control+d only scrolls one line at a time

### DIFF
--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -197,6 +197,43 @@ MU_TEST(test_no_scroll_after_setting_left)
   mu_check(vimWindowGetLeftColumn() == 3);
 }
 
+MU_TEST(test_ctrl_d)
+{
+  vimWindowSetHeight(50);
+  vimInput("g");
+  vimInput("g");
+  printf("topline: %d\n", 1);
+  
+  vimInput("<c-d>");
+
+  printf("topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 26);
+
+  vimWindowSetHeight(12);
+
+  vimInput("<c-u>");
+  mu_check(vimWindowGetTopLine() == 20);
+}
+
+/*MU_TEST(test_ctrl_f)
+{
+  vimWindowSetHeight(50);
+  vimInput("g");
+  vimInput("g");
+  printf("topline: %d\n", 1);
+  
+  vimInput("<c-f>");
+
+  printf("topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 49);
+
+  vimWindowSetHeight(6);
+  
+  vimInput("<c-f>");
+  printf("topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 54);
+}*/
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -209,6 +246,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_no_scroll_after_setting_topline);
   MU_RUN_TEST(test_scroll_left_at_boundary);
   MU_RUN_TEST(test_no_scroll_after_setting_left);
+  MU_RUN_TEST(test_ctrl_d);
+  /*MU_RUN_TEST(test_ctrl_f);*/
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -222,7 +222,7 @@ MU_TEST(test_ctrl_f)
   vimInput("g");
   vimInput("g");
   printf("topline: %d\n", 1);
-  
+
   vimInput("<c-f>");
 
   printf("topline: %d\n", vimWindowGetTopLine());
@@ -231,17 +231,17 @@ MU_TEST(test_ctrl_f)
   // When setting the height, the view may not be centered,
   // so the next <c-f> will be a partial scroll
   vimWindowSetHeight(20);
-  
+
   vimInput("<c-f>");
   // Partial scroll after resize
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 58);
-  
+
   // Full scroll
   vimInput("<c-f>");
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 76);
-  
+
   // Full scroll
   vimInput("<c-f>");
   printf("topline: %d\n", vimWindowGetTopLine());

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -203,7 +203,7 @@ MU_TEST(test_ctrl_d)
   vimInput("g");
   vimInput("g");
   printf("topline: %d\n", 1);
-  
+
   vimInput("<c-d>");
 
   printf("topline: %d\n", vimWindowGetTopLine());

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -216,7 +216,7 @@ MU_TEST(test_ctrl_d)
   mu_check(vimWindowGetTopLine() == 20);
 }
 
-/*MU_TEST(test_ctrl_f)
+MU_TEST(test_ctrl_f)
 {
   vimWindowSetHeight(50);
   vimInput("g");
@@ -228,12 +228,25 @@ MU_TEST(test_ctrl_d)
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 49);
 
-  vimWindowSetHeight(6);
+  // When setting the height, the view may not be centered,
+  // so the next <c-f> will be a partial scroll
+  vimWindowSetHeight(20);
   
   vimInput("<c-f>");
+  // Partial scroll after resize
   printf("topline: %d\n", vimWindowGetTopLine());
-  mu_check(vimWindowGetTopLine() == 54);
-}*/
+  mu_check(vimWindowGetTopLine() == 58);
+  
+  // Full scroll
+  vimInput("<c-f>");
+  printf("topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 76);
+  
+  // Full scroll
+  vimInput("<c-f>");
+  printf("topline: %d\n", vimWindowGetTopLine());
+  mu_check(vimWindowGetTopLine() == 94);
+}
 
 MU_TEST_SUITE(test_suite)
 {
@@ -248,7 +261,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_scroll_left_at_boundary);
   MU_RUN_TEST(test_no_scroll_after_setting_left);
   MU_RUN_TEST(test_ctrl_d);
-  /*MU_RUN_TEST(test_ctrl_f);*/
+  MU_RUN_TEST(test_ctrl_f);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -318,6 +318,8 @@ void vimWindowSetHeight(int height)
   }
 
   win_new_height(curwin, height);
+  // Set scroll value so that <c-d>/<c-u> work as expected
+  win_comp_scroll(curwin);
 }
 
 int vimGetMode(void) { return get_real_state(); }


### PR DESCRIPTION
This is the libvim-side fix for https://github.com/onivim/oni2/issues/519

__Issue:__ When pressing `<Control+d>` in normal mode, only a single line is scrolled.

__Defect:__ The logic here for determining how many lines to scroll: https://github.com/onivim/libvim/blob/5f42e8565f0d272e092b877efe47847df2210c75/src/move.c#L2295

Wasn't working as expected. The `curwin->w_p_scr` value was always set to `1`, causing the `n` value used for scrolling to be `1` as well.

__Fix:__ Call `win_comp_scroll` whenever the height changes - this sets `curwin->w_p_scr` for the correct value based on the height.