### PR TITLE
Clipboard: Allow external provider to override default register

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -759,7 +759,6 @@ void get_yank_register_value(int regname, int *num_lines, char_u ***lines)
  */
 int get_yank_register(int regname, int writing)
 {
-  printf("get_yank_register - regname: %d | writing: %d\n", regname, writing);
   int i;
   int ret = FALSE;
 
@@ -769,10 +768,8 @@ int get_yank_register(int regname, int writing)
   char_u **lines;
   int useExternalClipboard = 0;
 
-
   if (clipboardGetCallback != NULL && !writing)
   {
-    printf("-- get_yank_register: calling clipboardGetCallback...\n");
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
 
@@ -780,16 +777,16 @@ int get_yank_register(int regname, int writing)
   {
     y_current = y_previous;
 
-    if (useExternalClipboard) {
-      printf("-- get_yank_register: freeing!\n");
+    if (useExternalClipboard)
+    {
       free_yank_all(); /* free register */
       y_current->y_type = MLINE;
       y_current->y_size = num_lines;
       y_current->y_array = lines;
 
-  #ifdef FEAT_VIMINFO
+#ifdef FEAT_VIMINFO
       y_current->y_time_set = vim_time();
-  #endif
+#endif
 
       for (int i = 0; i < num_lines; i++)
       {
@@ -820,19 +817,18 @@ int get_yank_register(int regname, int writing)
       i = PLUS_REGISTER;
 
     y_current = &y_regs[i];
-    
+
     /* update star register */
     if (!writing && useExternalClipboard)
     {
-      printf("-- get_yank_register: freeing!\n");
       free_yank_all(); /* free register */
       y_current->y_type = MLINE;
       y_current->y_size = num_lines;
       y_current->y_array = lines;
 
-  #ifdef FEAT_VIMINFO
+#ifdef FEAT_VIMINFO
       y_current->y_time_set = vim_time();
-  #endif
+#endif
 
       for (int i = 0; i < num_lines; i++)
       {
@@ -848,8 +844,6 @@ int get_yank_register(int regname, int writing)
 
   if (writing) /* remember the register we write into for do_put() */
     y_previous = y_current;
-  
-  printf("-- get_yank_register: returning\n");
 
   return ret;
 }

--- a/src/ops.c
+++ b/src/ops.c
@@ -773,27 +773,13 @@ int get_yank_register(int regname, int writing)
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
 
+  if (useExternalClipboard && regname == 0) {
+    regname = '*';
+  }
+
   if ((regname == 0 || regname == '"') && !writing && y_previous != NULL)
   {
     y_current = y_previous;
-
-    if (useExternalClipboard)
-    {
-      free_yank_all(); /* free register */
-      y_current->y_type = MLINE;
-      y_current->y_size = num_lines;
-      y_current->y_array = lines;
-
-#ifdef FEAT_VIMINFO
-      y_current->y_time_set = vim_time();
-#endif
-
-      for (int i = 0; i < num_lines; i++)
-      {
-        y_current->y_array[i] = lines[i];
-      }
-    }
-
     return ret;
   }
 

--- a/src/ops.c
+++ b/src/ops.c
@@ -759,6 +759,7 @@ void get_yank_register_value(int regname, int *num_lines, char_u ***lines)
  */
 int get_yank_register(int regname, int writing)
 {
+  printf("get_yank_register - regname: %d | writing: %d\n", regname, writing);
   int i;
   int ret = FALSE;
 
@@ -768,12 +769,14 @@ int get_yank_register(int regname, int writing)
   char_u **lines;
   int useExternalClipboard = 0;
 
+
   if (clipboardGetCallback != NULL && !writing)
   {
+    printf("-- get_yank_register: calling clipboardGetCallback...\n");
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
 
-  if (useExternalClipboard && regname == 0)
+  if (useExternalClipboard == TRUE && regname == 0)
   {
     regname = '*';
   }
@@ -781,6 +784,14 @@ int get_yank_register(int regname, int writing)
   if ((regname == 0 || regname == '"') && !writing && y_previous != NULL)
   {
     y_current = y_previous;
+
+    if (useExternalClipboard) {
+      for (int i = 0; i < num_lines; i++) {
+        vim_free(lines[i]);
+      }
+      vim_free(lines);
+    }
+
     return ret;
   }
 
@@ -808,6 +819,7 @@ int get_yank_register(int regname, int writing)
     /* update star register */
     if (!writing && useExternalClipboard)
     {
+      printf("-- get_yank_register: freeing!\n");
       free_yank_all(); /* free register */
       y_current->y_type = MLINE;
       y_current->y_size = num_lines;
@@ -831,6 +843,8 @@ int get_yank_register(int regname, int writing)
 
   if (writing) /* remember the register we write into for do_put() */
     y_previous = y_current;
+  
+  printf("-- get_yank_register: returning\n");
 
   return ret;
 }

--- a/src/ops.c
+++ b/src/ops.c
@@ -763,20 +763,22 @@ int get_yank_register(int regname, int writing)
   int ret = FALSE;
 
   y_append = FALSE;
-  
+
   int num_lines;
   char_u **lines;
   int useExternalClipboard = 0;
 
-  if (clipboardGetCallback != NULL) {
+  if (clipboardGetCallback != NULL)
+  {
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
-  
+
   if ((regname == 0 || regname == '"') && !writing && y_previous != NULL)
   {
     y_current = y_previous;
 
-    if (useExternalClipboard) {
+    if (useExternalClipboard)
+    {
       free_yank_all(); /* free register */
       y_current->y_type = MLINE;
       y_current->y_size = num_lines;
@@ -824,19 +826,19 @@ int get_yank_register(int regname, int writing)
 
   if (!writing && useExternalClipboard)
   {
-      free_yank_all(); /* free register */
-      y_current->y_type = MLINE;
-      y_current->y_size = num_lines;
-      y_current->y_array = lines;
+    free_yank_all(); /* free register */
+    y_current->y_type = MLINE;
+    y_current->y_size = num_lines;
+    y_current->y_array = lines;
 
 #ifdef FEAT_VIMINFO
-      y_current->y_time_set = vim_time();
+    y_current->y_time_set = vim_time();
 #endif
 
-      for (int i = 0; i < num_lines; i++)
-      {
-        y_current->y_array[i] = lines[i];
-      }
+    for (int i = 0; i < num_lines; i++)
+    {
+      y_current->y_array[i] = lines[i];
+    }
   }
 
   if (writing) /* remember the register we write into for do_put() */

--- a/src/ops.c
+++ b/src/ops.c
@@ -776,20 +776,25 @@ int get_yank_register(int regname, int writing)
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
 
-  if (useExternalClipboard == TRUE && regname == 0)
-  {
-    regname = '*';
-  }
-
   if ((regname == 0 || regname == '"') && !writing && y_previous != NULL)
   {
     y_current = y_previous;
 
     if (useExternalClipboard) {
-      for (int i = 0; i < num_lines; i++) {
-        vim_free(lines[i]);
+      printf("-- get_yank_register: freeing!\n");
+      free_yank_all(); /* free register */
+      y_current->y_type = MLINE;
+      y_current->y_size = num_lines;
+      y_current->y_array = lines;
+
+  #ifdef FEAT_VIMINFO
+      y_current->y_time_set = vim_time();
+  #endif
+
+      for (int i = 0; i < num_lines; i++)
+      {
+        y_current->y_array[i] = lines[i];
       }
-      vim_free(lines);
     }
 
     return ret;

--- a/src/ops.c
+++ b/src/ops.c
@@ -773,7 +773,8 @@ int get_yank_register(int regname, int writing)
     useExternalClipboard = clipboardGetCallback(regname, &num_lines, &lines);
   }
 
-  if (useExternalClipboard && regname == 0) {
+  if (useExternalClipboard && regname == 0)
+  {
     regname = '*';
   }
 


### PR DESCRIPTION
This functionality is to support the clipboard mode of a `"paste"` in Onivim - in this mode, if a register is not specified, the `p` default behavior will pull from the clipboard. (It would really only make sense to do this if you had the `"yank"` behavior specified too, so that yanks are pushed to the clipboard).