### PR TITLE
Bugfix: zero-alloc when no search matches

### DIFF
--- a/src/libvim.c
+++ b/src/libvim.c
@@ -197,10 +197,10 @@ void vimSearchGetHighlights(linenr_T start_lnum, linenr_T end_lnum,
 
   char_u *pattern = get_search_pat();
 
+  *num_highlights = 0;
+  *highlights = NULL;
   if (pattern == NULL)
   {
-    *num_highlights = 0;
-    *highlights = NULL;
     return;
   }
 
@@ -236,6 +236,12 @@ void vimSearchGetHighlights(linenr_T start_lnum, linenr_T end_lnum,
     startPos = endPos;
     startPos.col = startPos.col + 1;
     count++;
+  }
+
+  if (count == 0)
+  {
+    vim_free(head);
+    return;
   }
 
   searchHighlight_T *ret = alloc(sizeof(searchHighlight_T) * count);


### PR DESCRIPTION
While experimenting with adding external messages in https://github.com/onivim/oni2/pull/611, I saw we were getting messages of the form: `title: || contents: |E341: Internal error: lalloc(0, )|.` This is distracting and we shouldn't be getting internal errors bubbling up...

It turns out this is a bug with the way we externalized the search highlights - in the case there are no matches, we'd do a zero-size allocation. This fixes that particular case and adds a test to exercise it.