### PR TITLE
API: Go-to definition / Go-to declaration

### DIFF
--- a/src/apitest/goto.c
+++ b/src/apitest/goto.c
@@ -6,12 +6,13 @@ static int lastLnum = 0;
 static int lastCol = 0;
 static gotoTarget_T lastTarget = DEFINITION;
 
-void onGoto(gotoRequest_T gotoRequest)
+int onGoto(gotoRequest_T gotoRequest)
 {
   lastLnum = gotoRequest.location.lnum;
   lastCol = gotoRequest.location.col;
   lastTarget = gotoRequest.target;
   gotoCount++;
+  return 1;
 }
 
 void test_setup(void)

--- a/src/apitest/goto.c
+++ b/src/apitest/goto.c
@@ -1,0 +1,91 @@
+#include "libvim.h"
+#include "minunit.h"
+
+static int gotoCount = 0;
+static int lastLnum = 0;
+static int lastCol = 0;
+static gotoTarget_T lastTarget = DEFINITION;
+
+void onGoto(gotoRequest_T gotoRequest)
+{
+  lastLnum = gotoRequest.location.lnum;
+  lastCol = gotoRequest.location.col;
+  lastTarget = gotoRequest.target;
+  gotoCount++;
+}
+
+void test_setup(void)
+{
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+
+  gotoCount = 0;
+  lastLnum = 0;
+  lastCol = 0;
+  lastTarget = DEFINITION;
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_goto_definition)
+{
+  vimInput("g");
+  vimInput("d");
+
+  mu_check(gotoCount == 1);
+  mu_check(lastLnum == 1);
+  mu_check(lastCol == 0);
+  mu_check(lastTarget == DEFINITION);
+}
+
+MU_TEST(test_goto_declaration)
+{
+  vimInput("g");
+  vimInput("D");
+
+  mu_check(gotoCount == 1);
+  mu_check(lastLnum == 1);
+  mu_check(lastCol == 0);
+  mu_check(lastTarget == DECLARATION);
+}
+
+// TODO: Implement goto-implementation
+/*MU_TEST(test_goto_implementation)
+{
+  vimInput("<C-]>");
+
+  mu_check(gotoCount == 1);
+  mu_check(lastLnum == 1);
+  mu_check(lastCol == 1);
+  mu_check(lastTarget == IMPLEMENTATION);
+}*/
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_goto_definition);
+  MU_RUN_TEST(test_goto_declaration);
+  //MU_RUN_TEST(test_goto_implementation);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  vimSetGotoCallback(&onGoto);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/globals.h
+++ b/src/globals.h
@@ -49,6 +49,7 @@ EXTERN AutoCommandCallback autoCommandCallback INIT(= NULL);
 EXTERN BufferUpdateCallback bufferUpdateCallback INIT(= NULL);
 EXTERN ClipboardGetCallback clipboardGetCallback INIT(= NULL);
 EXTERN DirectoryChangedCallback directoryChangedCallback INIT(= NULL);
+EXTERN GotoCallback gotoCallback INIT(= NULL);
 EXTERN VoidCallback displayIntroCallback INIT(= NULL);
 EXTERN VoidCallback displayVersionCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -336,6 +336,11 @@ void vimSetClipboardGetCallback(ClipboardGetCallback callback)
 
 int vimGetMode(void) { return get_real_state(); }
 
+void vimSetGotoCallback(GotoCallback callback)
+{
+  gotoCallback = callback;
+}
+
 void vimSetDisplayIntroCallback(VoidCallback callback)
 {
   displayIntroCallback = callback;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -85,6 +85,7 @@ void vimSetMessageCallback(MessageCallback messageCallback);
  * Misc
  **/
 
+void vimSetGotoCallback(GotoCallback gotoCallback);
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -3017,7 +3017,12 @@ static void nv_page(cmdarg_T *cap)
 static void nv_gd(oparg_T *oap, int nchar,
                   int thisblock) /* 1 for "1gd" and "1gD" */
 {
-  int len;
+  gotoRequest_T gotoRequest;
+
+  gotoRequest.location = curwin->w_cursor;
+  gotoRequest.target = nchar == 'd' ? DEFINITION : DECLARATION;
+  gotoCallback(gotoRequest);
+  /*int len;
   char_u *ptr;
 
   if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0 ||
@@ -3026,7 +3031,7 @@ static void nv_gd(oparg_T *oap, int nchar,
 #ifdef FEAT_FOLDING
   else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP)
     foldOpenCursor();
-#endif
+#endif*/
 }
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -3022,16 +3022,6 @@ static void nv_gd(oparg_T *oap, int nchar,
   gotoRequest.location = curwin->w_cursor;
   gotoRequest.target = nchar == 'd' ? DEFINITION : DECLARATION;
   gotoCallback(gotoRequest);
-  /*int len;
-  char_u *ptr;
-
-  if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0 ||
-      find_decl(ptr, len, nchar == 'd', thisblock, SEARCH_START) == FAIL)
-    clearopbeep(oap);
-#ifdef FEAT_FOLDING
-  else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP)
-    foldOpenCursor();
-#endif*/
 }
 
 /*

--- a/src/structs.h
+++ b/src/structs.h
@@ -92,7 +92,7 @@ typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);
 typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count);
 typedef void (*YankCallback)(yankInfo_T *yankInfo);
-typedef void (*GotoCallback)(gotoRequest_T gotoInfo);
+typedef int (*GotoCallback)(gotoRequest_T gotoInfo);
 
 typedef struct
 {

--- a/src/structs.h
+++ b/src/structs.h
@@ -73,11 +73,26 @@ typedef struct
   char_u **lines;
 } yankInfo_T;
 
+typedef enum
+{
+  DEFINITION,
+  DECLARATION,
+  IMPLEMENTATION,
+  TYPEDEFINITION,
+} gotoTarget_T;
+
+typedef struct
+{
+  pos_T location;
+  gotoTarget_T target;
+} gotoRequest_T;
+
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);
 typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count);
 typedef void (*YankCallback)(yankInfo_T *yankInfo);
+typedef void (*GotoCallback)(gotoRequest_T gotoInfo);
 
 typedef struct
 {


### PR DESCRIPTION
This externalizes the `gd` and `gD` commands so that they can be handled by the `libvim` consumer. For Onivim 2, we will forward this to a language provider to handle.

__TODO:__ 
- [x] Return a `bool` and bring back Vim default behavior, for filetypes where we don't have LSP integration