### PR TITLE
Bugfix: Goto definition crash

### DIFF
--- a/src/apitest/goto.c
+++ b/src/apitest/goto.c
@@ -18,7 +18,7 @@ int onGoto(gotoRequest_T gotoRequest)
 void test_setup(void)
 {
   vimSetGotoCallback(&onGoto);
-  
+
   vimInput("<esc>");
   vimInput("<esc>");
 

--- a/src/apitest/goto.c
+++ b/src/apitest/goto.c
@@ -17,6 +17,8 @@ int onGoto(gotoRequest_T gotoRequest)
 
 void test_setup(void)
 {
+  vimSetGotoCallback(&onGoto);
+  
   vimInput("<esc>");
   vimInput("<esc>");
 
@@ -32,6 +34,15 @@ void test_setup(void)
 }
 
 void test_teardown(void) {}
+
+MU_TEST(test_goto_no_callback)
+{
+  vimSetGotoCallback(NULL);
+  vimInput("g");
+  vimInput("d");
+
+  mu_check(gotoCount == 0);
+}
 
 MU_TEST(test_goto_definition)
 {
@@ -70,6 +81,7 @@ MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
+  MU_RUN_TEST(test_goto_no_callback);
   MU_RUN_TEST(test_goto_definition);
   MU_RUN_TEST(test_goto_declaration);
   //MU_RUN_TEST(test_goto_implementation);

--- a/src/normal.c
+++ b/src/normal.c
@@ -3015,7 +3015,11 @@ static void nv_gd(oparg_T *oap, int nchar,
 
   gotoRequest.location = curwin->w_cursor;
   gotoRequest.target = nchar == 'd' ? DEFINITION : DECLARATION;
-  int handled = gotoCallback(gotoRequest);
+  int handled = 0;
+
+  if (gotoCallback != NULL) {
+    handled = gotoCallback(gotoRequest);
+  }
 
   if (!handled)
   {

--- a/src/normal.c
+++ b/src/normal.c
@@ -3017,7 +3017,8 @@ static void nv_gd(oparg_T *oap, int nchar,
   gotoRequest.target = nchar == 'd' ? DEFINITION : DECLARATION;
   int handled = 0;
 
-  if (gotoCallback != NULL) {
+  if (gotoCallback != NULL)
+  {
     handled = gotoCallback(gotoRequest);
   }
 


### PR DESCRIPTION
__Issue:__ `libvim` would segfault when executing `gd` in the case no callback was set via `vimSetGotoCallback`.

__Defect:__ We weren't checking that `gotoCallback` was non-null prior to calling.

__Fix:__ Add null-check