### PR TITLE
N-Squared D fix.

### DIFF
--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -128,19 +128,14 @@ MU_TEST(test_delete_large_n_lines)
 MU_TEST(test_delete_mn_lines)
 {
   vimBufferOpen("collateral/lines_100.txt", 1, 0);
-  printf("=5=========================================================\n");
   vimInput("5");
-  printf("=d=========================================================\n");
   vimInput("d");
-  printf("=3=========================================================\n");
-  vimInput("3");
-  printf("=d=========================================================\n");
+  vimInput("5");
   vimInput("d");
-  printf("===========================================================\n");
 
   mu_check(updateCount == 1);
-  mu_check((lastLnume - lastLnum) == 15);
-  mu_check(lastXtra == -15);
+  mu_check((lastLnume - lastLnum) == 25);
+  mu_check(lastXtra == -25);
   mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
 }
 

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -128,10 +128,15 @@ MU_TEST(test_delete_large_n_lines)
 MU_TEST(test_delete_mn_lines)
 {
   vimBufferOpen("collateral/lines_100.txt", 1, 0);
+  printf("=5=========================================================\n");
   vimInput("5");
+  printf("=d=========================================================\n");
   vimInput("d");
+  printf("=3=========================================================\n");
   vimInput("3");
+  printf("=d=========================================================\n");
   vimInput("d");
+  printf("===========================================================\n");
 
   mu_check(updateCount == 1);
   mu_check((lastLnume - lastLnum) == 15);

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -111,6 +111,34 @@ MU_TEST(test_delete_n_lines)
   mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
 }
 
+MU_TEST(test_delete_large_n_lines)
+{
+  vimBufferOpen("collateral/lines_100.txt", 1, 0);
+  vimInput("5");
+  vimInput("5");
+  vimInput("d");
+  vimInput("d");
+
+  mu_check(updateCount == 1);
+  mu_check((lastLnume - lastLnum) == 55);
+  mu_check(lastXtra == -55);
+  mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
+}
+
+MU_TEST(test_delete_mn_lines)
+{
+  vimBufferOpen("collateral/lines_100.txt", 1, 0);
+  vimInput("5");
+  vimInput("d");
+  vimInput("3");
+  vimInput("d");
+
+  mu_check(updateCount == 1);
+  mu_check((lastLnume - lastLnum) == 15);
+  mu_check(lastXtra == -15);
+  mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
+}
+
 MU_TEST(test_insert)
 {
   vimInput("i");
@@ -175,6 +203,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_reset_modified_after_reload);
   MU_RUN_TEST(test_reset_modified_after_undo);
   MU_RUN_TEST(test_delete_n_lines);
+  MU_RUN_TEST(test_delete_large_n_lines);
+  MU_RUN_TEST(test_delete_mn_lines);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -98,6 +98,19 @@ MU_TEST(test_delete_multiple_lines)
   mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
 }
 
+MU_TEST(test_delete_n_lines)
+{
+  vimBufferOpen("collateral/lines_100.txt", 1, 0);
+  vimInput("5");
+  vimInput("d");
+  vimInput("d");
+  
+  mu_check(updateCount == 1);
+  mu_check((lastLnume - lastLnum) == 5);
+  mu_check(lastXtra == -5);
+  mu_check(lastVersionAtUpdateTime == vimBufferGetLastChangedTick(curbuf));
+}
+
 MU_TEST(test_insert)
 {
   vimInput("i");
@@ -161,6 +174,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_modified);
   MU_RUN_TEST(test_reset_modified_after_reload);
   MU_RUN_TEST(test_reset_modified_after_undo);
+  MU_RUN_TEST(test_delete_n_lines);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -104,7 +104,7 @@ MU_TEST(test_delete_n_lines)
   vimInput("5");
   vimInput("d");
   vimInput("d");
-  
+
   mu_check(updateCount == 1);
   mu_check((lastLnume - lastLnum) == 5);
   mu_check(lastXtra == -5);

--- a/src/normal.c
+++ b/src/normal.c
@@ -805,6 +805,7 @@ restart_state:
     if (finish_op && !previous_finish_op && !VIsual_active)
     {
       context->state = NORMAL_START_COUNT;
+      context->ca.opcount = 0;
       return HANDLED;
     }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -608,6 +608,9 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c)
   oparg_T *oap = context->oap;
 
 restart_state:
+  printf("We are running with state %i\n", context->state);
+  printf("At the start of this state, the opcount is %li\n", context->ca.opcount);
+  printf("At the start of this state, the count0 is %li\n", context->ca.count0);
   switch (context->state)
   {
   case NORMAL_INITIAL:
@@ -647,6 +650,8 @@ restart_state:
     context->state = NORMAL_START_COUNT;
     goto restart_state;
   case NORMAL_START_COUNT:
+    printf("Input params: c=%i, count0=%li\n", c, context->ca.count0);
+    printf("Bool normal start count: %i\n", (!((c >= '1' && c <= '9') || (context->ca.count0 != 0 && (c == K_DEL || c == K_KDEL || c == '0')))));
     if (!((c >= '1' && c <= '9') ||
           (context->ca.count0 != 0 &&
            (c == K_DEL || c == K_KDEL || c == '0'))))
@@ -666,8 +671,11 @@ restart_state:
     {
       context->ca.count0 /= 10;
     }
-    else
+    else {
+      printf("Input params: c=%i, count0=%li\n", c, context->ca.count0);
+      printf("C0*10: %li, c-0: %i, tot: %li \n", (context->ca.count0 * 10), (c - '0'), (context->ca.count0 * 10 + (c - '0')));
       context->ca.count0 = context->ca.count0 * 10 + (c - '0');
+    }
     if (context->ca.count0 < 0) /* got too large! */
       context->ca.count0 = 999999999L;
 #ifdef FEAT_EVAL
@@ -797,6 +805,7 @@ restart_state:
     int stateMode = sm_get_current_mode();
     if (stateMode != NORMAL)
     {
+      printf("7-1...\n");
       context->returnState = stateMode;
       context->returnPriorPosition = curwin->w_cursor;
       return HANDLED;
@@ -804,10 +813,13 @@ restart_state:
 
     if (finish_op && !previous_finish_op && !VIsual_active)
     {
+      printf("7-2...\n");
       context->state = NORMAL_START_COUNT;
       context->ca.opcount = 0;
       return HANDLED;
     }
+
+    printf("We are running with %li\n", context->ca.opcount);
 
     /*
      * If we didn't start or finish an operator, reset oap->regname, unless we

--- a/src/normal.c
+++ b/src/normal.c
@@ -807,7 +807,7 @@ restart_state:
       context->state = NORMAL_START_COUNT;
       context->ca.count0 = 0;
 #ifdef FEAT_EVAL
-    context->set_prevcount = TRUE;
+      context->set_prevcount = TRUE;
 #endif
       return HANDLED;
     }

--- a/src/normal.c
+++ b/src/normal.c
@@ -608,9 +608,6 @@ executionStatus_T state_normal_cmd_execute(void *ctx, int c)
   oparg_T *oap = context->oap;
 
 restart_state:
-  printf("We are running with state %i\n", context->state);
-  printf("At the start of this state, the opcount is %li\n", context->ca.opcount);
-  printf("At the start of this state, the count0 is %li\n", context->ca.count0);
   switch (context->state)
   {
   case NORMAL_INITIAL:
@@ -650,8 +647,6 @@ restart_state:
     context->state = NORMAL_START_COUNT;
     goto restart_state;
   case NORMAL_START_COUNT:
-    printf("Input params: c=%i, count0=%li\n", c, context->ca.count0);
-    printf("Bool normal start count: %i\n", (!((c >= '1' && c <= '9') || (context->ca.count0 != 0 && (c == K_DEL || c == K_KDEL || c == '0')))));
     if (!((c >= '1' && c <= '9') ||
           (context->ca.count0 != 0 &&
            (c == K_DEL || c == K_KDEL || c == '0'))))
@@ -671,11 +666,8 @@ restart_state:
     {
       context->ca.count0 /= 10;
     }
-    else {
-      printf("Input params: c=%i, count0=%li\n", c, context->ca.count0);
-      printf("C0*10: %li, c-0: %i, tot: %li \n", (context->ca.count0 * 10), (c - '0'), (context->ca.count0 * 10 + (c - '0')));
+    else
       context->ca.count0 = context->ca.count0 * 10 + (c - '0');
-    }
     if (context->ca.count0 < 0) /* got too large! */
       context->ca.count0 = 999999999L;
 #ifdef FEAT_EVAL
@@ -805,7 +797,6 @@ restart_state:
     int stateMode = sm_get_current_mode();
     if (stateMode != NORMAL)
     {
-      printf("7-1...\n");
       context->returnState = stateMode;
       context->returnPriorPosition = curwin->w_cursor;
       return HANDLED;
@@ -813,13 +804,13 @@ restart_state:
 
     if (finish_op && !previous_finish_op && !VIsual_active)
     {
-      printf("7-2...\n");
       context->state = NORMAL_START_COUNT;
-      context->ca.opcount = 0;
+      context->ca.count0 = 0;
+#ifdef FEAT_EVAL
+    context->set_prevcount = TRUE;
+#endif
       return HANDLED;
     }
-
-    printf("We are running with %li\n", context->ca.opcount);
 
     /*
      * If we didn't start or finish an operator, reset oap->regname, unless we


### PR DESCRIPTION
A quick test of a fix for the n-squared delete issue: https://github.com/onivim/oni2/issues/561

As far as I can tell, elsewhere in the code, when we bail out of a command as it has not completed, we set `opcount = 0`. However, at this location (that runs when a command is not complete) we do not.

This means on the second pass through for the final `d` (in an example command of `5dd`) we have `5` in `opcount` and `5` in `count0`. This is actually a valid state in vim, since you could do `2d2d` to delete 4 lines. So when we have `5` in both, they get multiplied together to give us the final n squared.

Setting it back to `0` here seems to be consistent with the other parts of the code, and fixes the issue, but I'm going to do some more checks I think.

@bryphe, I think this part is mainly written specifically for Oni, so can you see if this looks sensible?