### PR TITLE
API: Externalize term command

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -88,12 +88,7 @@ else
 CHANNEL=$(GUI)
 endif
 
-# Set to yes to enable terminal support.
-ifeq (HUGE, $(FEATURES))
-TERMINAL=yes
-else
 TERMINAL=no
-endif
 
 ifndef CTAGS
 # this assumes ctags is Exuberant ctags

--- a/src/apitest/terminal.c
+++ b/src/apitest/terminal.c
@@ -1,0 +1,93 @@
+#include "libvim.h"
+#include "minunit.h"
+
+static int terminalCallCount = 0;
+static terminalRequest_t lastTerminalRequest;
+
+void onTerminal(terminalRequest_t *termRequest)
+{
+  lastTerminalRequest.cmd = strdup(termRequest->cmd);
+  lastTerminalRequest.curwin = termRequest->curwin;
+  printf("onTerminal called! %s\n", lastTerminalRequest.cmd);
+  terminalCallCount++;
+}
+
+void test_setup(void)
+{
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+}
+
+void test_teardown(void)
+{
+  free(lastTerminalRequest.cmd);
+  lastTerminalRequest.cmd = 0;
+
+  terminalCallCount = 0;
+}
+
+MU_TEST(test_term_bash)
+{
+  vimInput(":");
+  vimInput("t");
+  vimInput("e");
+  vimInput("r");
+  vimInput("m");
+  vimInput(" ");
+  vimInput("b");
+  vimInput("a");
+  vimInput("s");
+  vimInput("h");
+  vimInput("<cr>");
+
+  mu_check(terminalCallCount == 1);
+  mu_check(lastTerminalRequest.curwin == 0);
+  mu_check(strcmp(lastTerminalRequest.cmd, "bash") == 0);
+}
+
+MU_TEST(test_term_curwin)
+{
+  vimInput(":");
+  vimInput("t");
+  vimInput("e");
+  vimInput("r");
+  vimInput("m");
+  vimInput(" ");
+  vimInput("+");
+  vimInput("+");
+  vimInput("c");
+  vimInput("u");
+  vimInput("r");
+  vimInput("w");
+  vimInput("i");
+  vimInput("n");
+  vimInput("<cr>");
+
+  mu_check(terminalCallCount == 1);
+  mu_check(lastTerminalRequest.curwin == 1);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_term_bash);
+  MU_RUN_TEST(test_term_curwin);
+}
+
+int main(int argc, char **argv)
+{
+  vimSetTerminalCallback(&onTerminal);
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -43,6 +43,7 @@ static void ex_bnext(exarg_T *eap);
 static void ex_bprevious(exarg_T *eap);
 static void ex_brewind(exarg_T *eap);
 static void ex_blast(exarg_T *eap);
+static void ex_terminal(exarg_T *eap);
 static char_u *getargcmd(char_u **);
 static char_u *skip_cmd_arg(char_u *p, int rembs);
 static int getargopt(exarg_T *eap);
@@ -348,9 +349,6 @@ static void ex_folddo(exarg_T *eap);
 
 #ifndef FEAT_PROFILE
 #define ex_profile ex_ni
-#endif
-#ifndef FEAT_TERMINAL
-#define ex_terminal ex_ni
 #endif
 #if !defined(FEAT_X11) || !defined(FEAT_XCLIPBOARD)
 #define ex_xrestore ex_ni
@@ -10466,6 +10464,146 @@ int is_loclist_cmd(int cmdidx)
   return cmdnames[cmdidx].cmd_name[0] == 'l';
 }
 #endif
+
+void ex_terminal(exarg_T *eap)
+{
+  //typval_T argvar[2];
+  jobopt_T opt;
+  char_u *cmd;
+  char_u *tofree = NULL;
+
+  //clear_job_options(opt);
+  vim_memset(&opt, 0, sizeof(jobopt_T));
+  opt.jo_mode = MODE_RAW;
+  opt.jo_out_mode = MODE_RAW;
+  opt.jo_err_mode = MODE_RAW;
+  opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
+  //init_job_options(&opt);
+
+  cmd = eap->arg;
+  while (*cmd == '+' && *(cmd + 1) == '+')
+  {
+    char_u *p, *ep;
+
+    cmd += 2;
+    p = skiptowhite(cmd);
+    ep = vim_strchr(cmd, '=');
+    if (ep != NULL && ep < p)
+      p = ep;
+
+    if ((int)(p - cmd) == 5 && STRNICMP(cmd, "close", 5) == 0)
+      opt.jo_term_finish = 'c';
+    else if ((int)(p - cmd) == 7 && STRNICMP(cmd, "noclose", 7) == 0)
+      opt.jo_term_finish = 'n';
+    else if ((int)(p - cmd) == 4 && STRNICMP(cmd, "open", 4) == 0)
+      opt.jo_term_finish = 'o';
+    else if ((int)(p - cmd) == 6 && STRNICMP(cmd, "curwin", 6) == 0)
+      opt.jo_curwin = 1;
+    else if ((int)(p - cmd) == 6 && STRNICMP(cmd, "hidden", 6) == 0)
+      opt.jo_hidden = 1;
+    else if ((int)(p - cmd) == 9 && STRNICMP(cmd, "norestore", 9) == 0)
+      opt.jo_term_norestore = 1;
+    else if ((int)(p - cmd) == 4 && STRNICMP(cmd, "kill", 4) == 0 && ep != NULL)
+    {
+      opt.jo_set2 |= JO2_TERM_KILL;
+      opt.jo_term_kill = ep + 1;
+      p = skiptowhite(cmd);
+    }
+    else if ((int)(p - cmd) == 4 && STRNICMP(cmd, "rows", 4) == 0 && ep != NULL && isdigit(ep[1]))
+    {
+      opt.jo_set2 |= JO2_TERM_ROWS;
+      opt.jo_term_rows = atoi((char *)ep + 1);
+      p = skiptowhite(cmd);
+    }
+    else if ((int)(p - cmd) == 4 && STRNICMP(cmd, "cols", 4) == 0 && ep != NULL && isdigit(ep[1]))
+    {
+      opt.jo_set2 |= JO2_TERM_COLS;
+      opt.jo_term_cols = atoi((char *)ep + 1);
+      p = skiptowhite(cmd);
+    }
+    else if ((int)(p - cmd) == 3 && STRNICMP(cmd, "eof", 3) == 0 && ep != NULL)
+    {
+      char_u *buf = NULL;
+      char_u *keys;
+
+      p = skiptowhite(cmd);
+      *p = NUL;
+      keys = replace_termcodes(ep + 1, &buf, TRUE, TRUE, TRUE);
+      opt.jo_set2 |= JO2_EOF_CHARS;
+      opt.jo_eof_chars = vim_strsave(keys);
+      vim_free(buf);
+      *p = ' ';
+    }
+#ifdef MSWIN
+    else if ((int)(p - cmd) == 4 && STRNICMP(cmd, "type", 4) == 0 && ep != NULL)
+    {
+      int tty_type = NUL;
+
+      p = skiptowhite(cmd);
+      if (STRNICMP(ep + 1, "winpty", p - (ep + 1)) == 0)
+        tty_type = 'w';
+      else if (STRNICMP(ep + 1, "conpty", p - (ep + 1)) == 0)
+        tty_type = 'c';
+      else
+      {
+        semsg(e_invargval, "type");
+        goto theend;
+      }
+      opt.jo_set2 |= JO2_TTY_TYPE;
+      opt.jo_tty_type = tty_type;
+    }
+#endif
+    else
+    {
+      if (*p)
+        *p = NUL;
+      semsg(_("E181: Invalid attribute: %s"), cmd);
+      goto theend;
+    }
+    cmd = skipwhite(p);
+  }
+  if (*cmd == NUL)
+  {
+    /* Make a copy of 'shell', an autocommand may change the option. */
+    tofree = cmd = vim_strsave(p_sh);
+
+    /* default to close when the shell exits */
+    if (opt.jo_term_finish == NUL)
+      opt.jo_term_finish = 'c';
+  }
+
+  if (eap->addr_count > 0)
+  {
+    /* Write lines from current buffer to the job. */
+    opt.jo_set |= JO_IN_IO | JO_IN_BUF | JO_IN_TOP | JO_IN_BOT;
+    //opt.jo_io[PART_IN] = JIO_BUFFER;
+    //opt.jo_io_buf[PART_IN] = curbuf->b_fnum;
+    opt.jo_in_top = eap->line1;
+    opt.jo_in_bot = eap->line2;
+  }
+
+  /*argvar[0].v_type = VAR_STRING;
+  argvar[0].vval.v_string = cmd;
+  argvar[1].v_type = VAR_UNKNOWN;*/
+
+  if (terminalCallback)
+  {
+    terminalRequest_t *pRequest = malloc(sizeof(terminalRequest_t));
+    pRequest->rows = opt.jo_term_rows;
+    pRequest->cols = opt.jo_term_cols;
+    pRequest->finish = opt.jo_term_finish;
+    pRequest->curwin = opt.jo_curwin;
+    pRequest->hidden = opt.jo_hidden;
+    pRequest->cmd = cmd;
+
+    terminalCallback(pRequest);
+    free(pRequest);
+  }
+  vim_free(tofree);
+
+theend:
+  vim_free(opt.jo_eof_chars);
+}
 
 #if defined(FEAT_TIMERS) || defined(PROTO)
 int get_pressedreturn(void)

--- a/src/feature.h
+++ b/src/feature.h
@@ -795,6 +795,7 @@
 #undef FEAT_CLIENTSERVER
 #undef FEAT_CMDWIN
 #undef FEAT_CONCEAL
+#undef FEAT_TERMINAL
 
 /*
  * +footer		Motif only: Add a message area at the bottom of the

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,6 +55,7 @@ EXTERN VoidCallback displayIntroCallback INIT(= NULL);
 EXTERN VoidCallback displayVersionCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
 EXTERN QuitCallback quitCallback INIT(= NULL);
+EXTERN TerminalCallback terminalCallback INIT(= NULL);
 EXTERN VoidCallback stopSearchHighlightCallback INIT(= NULL);
 EXTERN VoidCallback unhandledEscapeCallback INIT(= NULL);
 EXTERN WindowSplitCallback windowSplitCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -89,6 +89,11 @@ void vimSetMessageCallback(MessageCallback f)
   messageCallback = f;
 }
 
+void vimSetTerminalCallback(TerminalCallback f)
+{
+  terminalCallback = f;
+}
+
 void vimSetWindowSplitCallback(WindowSplitCallback f)
 {
   windowSplitCallback = f;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -210,6 +210,12 @@ char_u *vimSearchGetPattern();
 void vimSetStopSearchHighlightCallback(VoidCallback callback);
 
 /***
+ * Terminal
+ */
+
+void vimSetTerminalCallback(TerminalCallback callback);
+
+/***
  * Window
  */
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1885,7 +1885,6 @@ typedef struct
   char_u jo_cwd_buf[NUMBUFLEN];
   char_u *jo_cwd;
 
-#ifdef FEAT_TERMINAL
   /* when non-zero run the job in a terminal window of this size */
   int jo_term_rows;
   int jo_term_cols;
@@ -1899,7 +1898,6 @@ typedef struct
   char_u *jo_eof_chars;
   char_u *jo_term_kill;
   int jo_tty_type; // first character of "tty_type"
-#endif
 } jobopt_T;
 
 #ifdef FEAT_EVAL

--- a/src/structs.h
+++ b/src/structs.h
@@ -87,11 +87,22 @@ typedef struct
   gotoTarget_T target;
 } gotoRequest_T;
 
+typedef struct
+{
+  char_u *cmd;
+  int rows;
+  int cols;
+  int curwin;
+  char finish;
+  int hidden;
+} terminalRequest_t;
+
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);
 typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count);
 typedef void (*YankCallback)(yankInfo_T *yankInfo);
+typedef void (*TerminalCallback)(terminalRequest_t *terminalRequest);
 typedef int (*GotoCallback)(gotoRequest_T gotoInfo);
 
 typedef struct

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -767,7 +767,6 @@ void ex_terminal(exarg_T *eap)
     terminalCallback(pRequest);
     free(pRequest);
   }
-  //term_start(argvar, NULL, &opt, eap->forceit ? TERM_START_FORCEIT : 0);
   vim_free(tofree);
 
 theend:

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -753,7 +753,21 @@ void ex_terminal(exarg_T *eap)
   argvar[0].v_type = VAR_STRING;
   argvar[0].vval.v_string = cmd;
   argvar[1].v_type = VAR_UNKNOWN;
-  term_start(argvar, NULL, &opt, eap->forceit ? TERM_START_FORCEIT : 0);
+
+  if (terminalCallback)
+  {
+    terminalRequest_t *pRequest = malloc(sizeof(terminalRequest_t));
+    pRequest->rows = opt.jo_term_rows;
+    pRequest->cols = opt.jo_term_cols;
+    pRequest->finish = opt.jo_term_finish;
+    pRequest->curwin = opt.jo_curwin;
+    pRequest->hidden = opt.jo_hidden;
+    pRequest->cmd = cmd;
+
+    terminalCallback(pRequest);
+    free(pRequest);
+  }
+  //term_start(argvar, NULL, &opt, eap->forceit ? TERM_START_FORCEIT : 0);
   vim_free(tofree);
 
 theend:

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -641,7 +641,7 @@ term_start(
  */
 void ex_terminal(exarg_T *eap)
 {
-  typval_T argvar[2];
+  //typval_T argvar[2];
   jobopt_T opt;
   char_u *cmd;
   char_u *tofree = NULL;
@@ -750,9 +750,9 @@ void ex_terminal(exarg_T *eap)
     opt.jo_in_bot = eap->line2;
   }
 
-  argvar[0].v_type = VAR_STRING;
+  /*argvar[0].v_type = VAR_STRING;
   argvar[0].vval.v_string = cmd;
-  argvar[1].v_type = VAR_UNKNOWN;
+  argvar[1].v_type = VAR_UNKNOWN;*/
 
   if (terminalCallback)
   {


### PR DESCRIPTION
Shim in a callback that passes context from the `:term` command, to make available to reason-libvim / Onivim 2.