### PR TITLE
Bugfix: Add test case for Control+G (and implement)

### DIFF
--- a/src/apitest/ctrl_g.c
+++ b/src/apitest/ctrl_g.c
@@ -1,0 +1,65 @@
+#include "libvim.h"
+#include "minunit.h"
+
+#define MAX_TEST_MESSAGE 8192
+
+char_u lastMessage[MAX_TEST_MESSAGE];
+char_u lastTitle[MAX_TEST_MESSAGE];
+msgPriority_T lastPriority;
+
+void onMessage(char_u *title, char_u *msg, msgPriority_T priority)
+{
+  printf("onMessage - title: |%s| contents: |%s|", title, msg);
+
+  assert(strlen(msg) < MAX_TEST_MESSAGE);
+  assert(strlen(title) < MAX_TEST_MESSAGE);
+
+  strcpy(lastMessage, msg);
+  strcpy(lastTitle, title);
+  lastPriority = priority;
+};
+
+void test_setup(void)
+{
+  vimSetMessageCallback(&onMessage);
+
+  vimInput("<esc>");
+  vimInput("<esc>");
+
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_fileinfo)
+{
+  vimInput("<c-g>");
+
+  char_u *expected = "\"collateral/testfile.txt\" line 1 of 3 --33\%-- col 1";
+  mu_check(strcmp(lastMessage, expected) == 0);
+  mu_check(lastPriority == MSG_INFO);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_fileinfo);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3253,28 +3253,10 @@ void fileinfo(
   (void)append_arg_number(curwin, (char_u *)buffer, IOSIZE,
                           !shortmess(SHM_FILE));
 
-  if (dont_truncate)
-  {
-    /* Temporarily set msg_scroll to avoid the message being truncated.
-	 * First call msg_start() to get the message in the right place. */
-    msg_start();
-    n = msg_scroll;
-    msg_scroll = TRUE;
-    msg(buffer);
-    msg_scroll = n;
-  }
-  else
-  {
-    p = (char *)msg_trunc_attr(buffer, FALSE, 0);
-    if (restart_edit != 0 || (msg_scrolled && !need_wait_return))
-      /* Need to repeat the message after redrawing when:
-	     * - When restart_edit is set (otherwise there will be a delay
-	     *   before redrawing).
-	     * - When the screen was scrolled but there is no wait-return
-	     *   prompt. */
-      set_keep_msg((char_u *)p, 0);
-  }
-
+  msg_T *msg = msg2_create(MSG_INFO);
+  msg2_put(buffer, msg);
+  msg2_send(msg);
+  msg2_free(msg);
   vim_free(buffer);
 }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -1468,21 +1468,6 @@ getcount:
     if (restart_edit != 0)
       State = INSERT;
 
-    /* If need to redraw, and there is a "keep_msg", redraw before the
-     * delay */
-    if (must_redraw && keep_msg != NULL && !emsg_on_display)
-    {
-      char_u *kmsg;
-
-      kmsg = keep_msg;
-      keep_msg = NULL;
-      /* showmode() will clear keep_msg, but we want to use it anyway */
-      update_screen(0);
-      /* now reset it, otherwise it's put in the history again */
-      keep_msg = kmsg;
-      msg_attr((char *)kmsg, keep_msg_attr);
-      vim_free(kmsg);
-    }
     setcursor();
     cursor_on();
     State = save_State;


### PR DESCRIPTION
Related: https://github.com/onivim/oni2/issues/1092

This properly implements the `fileinfo` method using `msg2` (although the keybinding is shadowed by default by the sneak mode `<C-g>`).