### PR TITLE
Bugfix: Crash when ':set si' is used

### DIFF
--- a/src/apitest/indentation.c
+++ b/src/apitest/indentation.c
@@ -1,0 +1,44 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void)
+{
+  vimInput("<esc>");
+  vimInput("<esc>");
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(regression_test_no_crash_after_set_si)
+{
+  vimInput(":set si<CR>");
+  vimInput("o");
+
+  mu_check(strcmp(vimBufferGetLine(curbuf, 2), "") == 0);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(regression_test_no_crash_after_set_si);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/feature.h
+++ b/src/feature.h
@@ -420,10 +420,6 @@
 #endif
 #endif
 
-#ifdef FEAT_NORMAL
-#define FEAT_SMARTINDENT
-#endif
-
 /*
  * +comments		'comments' option.
  */
@@ -795,6 +791,7 @@
 #undef FEAT_CLIENTSERVER
 #undef FEAT_CMDWIN
 #undef FEAT_CONCEAL
+#undef FEAT_SMARTINDENT
 #undef FEAT_TERMINAL
 
 /*


### PR DESCRIPTION
__Issue:__ `libvim` currently crashes when `smartindent` is set and a new line is opened.

__Fix:__ Turn off `FEAT_SMARTINDENT` - our plan is to offload the indentation logic to the consumer. In Onivim 2's case, we'll use the language configuration info to provide a smartindent-equivalent.

Related: https://github.com/onivim/oni2/issues/1417

Thanks @leavengood for the investigation!