### PR TITLE
[WIP] Feature: Comment toggling

### DIFF
--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -1,0 +1,84 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void)
+{
+  vimInput("<Esc>");
+  vimInput("<Esc>");
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+MU_TEST(test_toggle_uncommented)
+{
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+
+  mu_check(strcmp(line, "//This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_toggle_there_and_back_again)
+{
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+
+  mu_check(strcmp(line, "//This is the first line of a test file") == 0);
+  
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+
+  mu_check(strcmp(line, "This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_toggle_uncommented_visual)
+{
+  vimInput("V");
+  vimInput("g");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  
+  mu_check(strcmp(line, "//This is the first line of a test file") == 0);
+}
+
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_toggle_uncommented);
+  MU_RUN_TEST(test_toggle_there_and_back_again);
+  MU_RUN_TEST(test_toggle_uncommented_visual);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -38,7 +38,7 @@ MU_TEST(test_toggle_there_and_back_again)
   printf("LINE: %s\n", line);
 
   mu_check(strcmp(line, "//This is the first line of a test file") == 0);
-  
+
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -57,7 +57,7 @@ MU_TEST(test_toggle_uncommented_visual)
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   printf("LINE: %s\n", line);
-  
+
   mu_check(strcmp(line, "//This is the first line of a test file") == 0);
 }
 
@@ -65,7 +65,7 @@ MU_TEST(test_toggle_uncommented_visual_multi)
 {
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -78,7 +78,7 @@ MU_TEST(test_toggle_uncommented_visual_multi)
   char_u *line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
-  
+
   char_u *line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
@@ -88,7 +88,7 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
 {
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -101,16 +101,16 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
   char_u *line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
-  
+
   char_u *line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
-  
+
   // and back again
 
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -123,7 +123,7 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
   line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "This is the second line of a test file") == 0);
-  
+
   line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
@@ -147,7 +147,7 @@ MU_TEST(test_set_line_comment_multi_there_and_back_again)
   vimOptionSetLineComment("##");
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -160,16 +160,16 @@ MU_TEST(test_set_line_comment_multi_there_and_back_again)
   char_u *line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "##This is the second line of a test file") == 0);
-  
+
   char_u *line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
-  
+
   // and back again
 
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -182,7 +182,7 @@ MU_TEST(test_set_line_comment_multi_there_and_back_again)
   line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "This is the second line of a test file") == 0);
-  
+
   line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
@@ -211,7 +211,7 @@ MU_TEST(test_undo_visual_multi)
 {
   vimInput("V");
   vimInput("j");
-  
+
   mu_check(vimCursorGetLine() == 2);
 
   vimInput("g");
@@ -224,15 +224,15 @@ MU_TEST(test_undo_visual_multi)
   char_u *line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2: |%s|\n", line2);
   mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
-  
+
   char_u *line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
-  
+
   // and back again
 
   vimInput("u");
-  
+
   line1 = vimBufferGetLine(curbuf, 1);
   printf("LINE1, after undo: |%s|\n", line1);
   mu_check(strcmp(line1, "This is the first line of a test file") == 0);
@@ -240,7 +240,7 @@ MU_TEST(test_undo_visual_multi)
   line2 = vimBufferGetLine(curbuf, 2);
   printf("LINE2, after undo: |%s|\n", line2);
   mu_check(strcmp(line2, "This is the second line of a test file") == 0);
-  
+
   line3 = vimBufferGetLine(curbuf, 3);
   printf("LINE3, after undo: |%s|\n", line3);
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -10,6 +10,8 @@ void test_setup(void)
   vimInput("g");
   vimInput("g");
   vimInput("0");
+
+  vimOptionSetLineComment("//");
 }
 
 void test_teardown(void) {}
@@ -186,6 +188,64 @@ MU_TEST(test_set_line_comment_multi_there_and_back_again)
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
 }
 
+MU_TEST(test_undo)
+{
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+
+  mu_check(strcmp(line, "//This is the first line of a test file") == 0);
+
+  vimInput("u");
+
+  line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE, after undo: %s\n", line);
+
+  mu_check(strcmp(line, "This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_undo_visual_multi)
+{
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  char_u *line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "//This is the first line of a test file") == 0);
+
+  char_u *line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
+  
+  char_u *line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+  
+  // and back again
+
+  vimInput("u");
+  
+  line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1, after undo: |%s|\n", line1);
+  mu_check(strcmp(line1, "This is the first line of a test file") == 0);
+
+  line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2, after undo: |%s|\n", line2);
+  mu_check(strcmp(line2, "This is the second line of a test file") == 0);
+  
+  line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3, after undo: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -197,6 +257,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_toggle_there_and_back_again_visual_multi);
   MU_RUN_TEST(test_set_line_comment);
   MU_RUN_TEST(test_set_line_comment_multi_there_and_back_again);
+  MU_RUN_TEST(test_undo);
+  MU_RUN_TEST(test_undo_visual_multi);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -59,6 +59,73 @@ MU_TEST(test_toggle_uncommented_visual)
   mu_check(strcmp(line, "//This is the first line of a test file") == 0);
 }
 
+MU_TEST(test_toggle_uncommented_visual_multi)
+{
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  char_u *line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "//This is the first line of a test file") == 0);
+
+  char_u *line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
+  
+  char_u *line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+}
+
+MU_TEST(test_toggle_there_and_back_again_visual_multi)
+{
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  char_u *line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "//This is the first line of a test file") == 0);
+
+  char_u *line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "//This is the second line of a test file") == 0);
+  
+  char_u *line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+  
+  // and back again
+
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "This is the first line of a test file") == 0);
+
+  line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "This is the second line of a test file") == 0);
+  
+  line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+}
 
 MU_TEST_SUITE(test_suite)
 {
@@ -67,6 +134,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_toggle_uncommented);
   MU_RUN_TEST(test_toggle_there_and_back_again);
   MU_RUN_TEST(test_toggle_uncommented_visual);
+  MU_RUN_TEST(test_toggle_uncommented_visual_multi);
+  MU_RUN_TEST(test_toggle_there_and_back_again_visual_multi);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -88,9 +88,6 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
 {
   vimInput("V");
   vimInput("j");
-
-  mu_check(vimCursorGetLine() == 2);
-
   vimInput("g");
   vimInput("c");
 
@@ -110,9 +107,6 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
 
   vimInput("V");
   vimInput("j");
-
-  mu_check(vimCursorGetLine() == 2);
-
   vimInput("g");
   vimInput("c");
 
@@ -246,6 +240,54 @@ MU_TEST(test_undo_visual_multi)
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
 }
 
+MU_TEST(test_cursor_toggle_there_and_back_again)
+{
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  // and back again
+
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
+MU_TEST(test_cursor_toggle_there_and_back_again_visual_multi)
+{
+  vimInput("V");
+  vimInput("j");
+
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("g");
+  vimInput("c");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  // and back again
+
+  vimInput("V");
+  vimInput("j");
+
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("g");
+  vimInput("c");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -259,6 +301,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_set_line_comment_multi_there_and_back_again);
   MU_RUN_TEST(test_undo);
   MU_RUN_TEST(test_undo_visual_multi);
+  MU_RUN_TEST(test_cursor_toggle_there_and_back_again);
+  MU_RUN_TEST(test_cursor_toggle_there_and_back_again_visual_multi);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -127,6 +127,65 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
 }
 
+MU_TEST(test_set_line_comment)
+{
+  vimOptionSetLineComment("--");
+  vimInput("g");
+  vimInput("c");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+
+  mu_check(strcmp(line, "--This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_set_line_comment_multi_there_and_back_again)
+{
+  vimOptionSetLineComment("##");
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  char_u *line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "##This is the first line of a test file") == 0);
+
+  char_u *line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "##This is the second line of a test file") == 0);
+  
+  char_u *line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+  
+  // and back again
+
+  vimInput("V");
+  vimInput("j");
+  
+  mu_check(vimCursorGetLine() == 2);
+
+  vimInput("g");
+  vimInput("c");
+
+  line1 = vimBufferGetLine(curbuf, 1);
+  printf("LINE1: |%s|\n", line1);
+  mu_check(strcmp(line1, "This is the first line of a test file") == 0);
+
+  line2 = vimBufferGetLine(curbuf, 2);
+  printf("LINE2: |%s|\n", line2);
+  mu_check(strcmp(line2, "This is the second line of a test file") == 0);
+  
+  line3 = vimBufferGetLine(curbuf, 3);
+  printf("LINE3: |%s|\n", line3);
+  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -136,6 +195,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_toggle_uncommented_visual);
   MU_RUN_TEST(test_toggle_uncommented_visual_multi);
   MU_RUN_TEST(test_toggle_there_and_back_again_visual_multi);
+  MU_RUN_TEST(test_set_line_comment);
+  MU_RUN_TEST(test_set_line_comment_multi_there_and_back_again);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -347,8 +347,6 @@ void vimOptionSetLineComment(const char_u *str)
   vim_free(curbuf->b_oni_line_comment);
   curbuf->b_oni_line_comment = (char_u *)alloc(STRLEN(str) + 1);
 
-  printf("str: |%s|\n", str);
-
   if (curbuf->b_oni_line_comment != NULL)
   {
     strcpy(curbuf->b_oni_line_comment, str);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -342,6 +342,19 @@ void vimOptionSetInsertSpaces(int insertSpaces)
   }
 }
 
+void vimOptionSetLineComment(const char_u *str)
+{
+  vim_free(curbuf->b_oni_line_comment);
+  curbuf->b_oni_line_comment = (char_u *)alloc(STRLEN(str) + 1);
+
+  printf("str: |%s|\n", str);
+
+  if (curbuf->b_oni_line_comment != NULL)
+  {
+    strcpy(curbuf->b_oni_line_comment, str);
+  }
+}
+
 int vimOptionGetTabSize() { return curbuf->b_p_ts; }
 
 int vimOptionGetInsertSpaces(void) { return curbuf->b_p_et; }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -144,6 +144,7 @@ void vimSetUnhandledEscapeCallback(VoidCallback callback);
 
 void vimOptionSetTabSize(int tabSize);
 void vimOptionSetInsertSpaces(int insertSpaces);
+void vimOptionSetLineComment(char_u* str);
 
 int vimOptionGetInsertSpaces(void);
 int vimOptionGetTabSize(void);

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -144,7 +144,7 @@ void vimSetUnhandledEscapeCallback(VoidCallback callback);
 
 void vimOptionSetTabSize(int tabSize);
 void vimOptionSetInsertSpaces(int insertSpaces);
-void vimOptionSetLineComment(char_u* str);
+void vimOptionSetLineComment(char_u *str);
 
 int vimOptionGetInsertSpaces(void);
 int vimOptionGetTabSize(void);

--- a/src/normal.c
+++ b/src/normal.c
@@ -348,14 +348,13 @@ static const struct nv_cmd
 
 #define strstartswith(a,b) (!strncmp(a,b,strlen(b)))
 
-void toggle_comment() {
+void toggle_comment(linenr_T lnum) {
   const char_u *comment = "//";
   int commentlen = (int)STRLEN(comment);
-  linenr_T lnum = curwin->w_cursor.lnum;
   const char_u* line = ml_get(lnum);
   int linelen = (int)STRLEN(line);
   char_u *newp;
-
+    
   if (strstartswith(line, comment)) {
     newp = alloc((linelen - commentlen) + 1);
 
@@ -382,6 +381,20 @@ void toggle_comment() {
     ml_replace(lnum, newp, FALSE);
     inserted_bytes(lnum, 0, commentlen);
     curwin->w_cursor.col += commentlen;
+  }
+}
+
+void toggle_comment_lines(linenr_T start, linenr_T end) {
+  linenr_T lnum;
+
+  if (start > end) {
+    lnum = start;
+    start = end;
+    end = lnum;
+  }
+  
+  for (lnum = start; lnum <= end; lnum++) {
+    toggle_comment(lnum);
   }
 }
 
@@ -2305,7 +2318,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
       break;
 
     case OP_COMMENT:
-      toggle_comment();
+      toggle_comment_lines(oap->start.lnum, oap->end.lnum);
       break;
 
     default:

--- a/src/normal.c
+++ b/src/normal.c
@@ -349,13 +349,15 @@ static const struct nv_cmd
 #define strstartswith(a,b) (!strncmp(a,b,strlen(b)))
 
 void toggle_comment(linenr_T lnum) {
-  const char_u *comment = "//";
+  const char_u *comment = curbuf->b_oni_line_comment != NULL ? curbuf->b_oni_line_comment : (char_u *)"//";
   int commentlen = (int)STRLEN(comment);
   const char_u* line = ml_get(lnum);
   int linelen = (int)STRLEN(line);
   char_u *newp;
-    
+
   if (strstartswith(line, comment)) {
+    // remove comment
+
     newp = alloc((linelen - commentlen) + 1);
 
     if (newp == NULL)
@@ -368,6 +370,8 @@ void toggle_comment(linenr_T lnum) {
     ml_replace(lnum, newp, FALSE);
     curwin->w_cursor.col -= commentlen;
   } else {
+    // add comment
+
     newp = alloc(linelen + commentlen + 1);
 
     if (newp == NULL)

--- a/src/normal.c
+++ b/src/normal.c
@@ -387,7 +387,6 @@ void toggle_comment(linenr_T lnum)
     mch_memmove(newp, comment, (size_t)commentlen);
     mch_memmove(newp + commentlen, line, (size_t)(linelen + 1));
     ml_replace(lnum, newp, FALSE);
-    inserted_bytes(lnum, 0, commentlen);
   }
 }
 
@@ -404,13 +403,13 @@ void toggle_comment_lines(linenr_T start, linenr_T end)
   }
 
   for (lnum = start; lnum <= end; lnum++)
-  {
     toggle_comment(lnum);
-  }
 
   // set cursoor to beginning
   curwin->w_cursor.lnum = start;
   curwin->w_cursor.col = 0;
+
+  changed_lines(start, 0, end + 1, 0);
 }
 
 /* Number of commands in nv_cmds[]. */

--- a/src/normal.c
+++ b/src/normal.c
@@ -102,6 +102,7 @@ static void nv_g_cmd(cmdarg_T *cap);
 static void nv_dot(cmdarg_T *cap);
 static void nv_redo(cmdarg_T *cap);
 static void nv_Undo(cmdarg_T *cap);
+static void nv_c(cmdarg_T *cap);
 static void nv_tilde(cmdarg_T *cap);
 static void nv_operator(cmdarg_T *cap);
 #ifdef FEAT_EVAL
@@ -278,7 +279,7 @@ static const struct nv_cmd
     {'`', nv_gomark, NV_NCH_ALW, FALSE},
     {'a', nv_edit, NV_NCH, 0},
     {'b', nv_bck_word, 0, 0},
-    {'c', nv_operator, 0, 0},
+    {'c', nv_c, 0, 0},
     {'d', nv_operator, 0, 0},
     {'e', nv_wordcmd, 0, FALSE},
     {'f', nv_csearch, NV_NCH_ALW | NV_LANG, FORWARD},
@@ -6784,6 +6785,22 @@ static void nv_Undo(cmdarg_T *cap)
     u_undoline();
     curwin->w_set_curswant = TRUE;
   }
+}
+
+/*
+ * Handle "c" command.
+ */
+static void nv_c(cmdarg_T *cap)
+{
+  /* In Visual mode and typing "gcc" triggers an operator */
+  if (cap->oap->op_type == OP_COMMENT || VIsual_active)
+  {
+    /* translate "gcc" to "gcgc" */
+    cap->cmdchar = 'g';
+    cap->nchar = 'c';
+  }
+
+  nv_operator(cap);
 }
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -346,37 +346,41 @@ static const struct nv_cmd
     {K_PS, nv_edit, 0, 0},
 };
 
-#define strstartswith(a,b) (!strncmp(a,b,strlen(b)))
+#define strstartswith(a, b) (!strncmp(a, b, strlen(b)))
 
-void toggle_comment(linenr_T lnum) {
+void toggle_comment(linenr_T lnum)
+{
   const char_u *comment = curbuf->b_oni_line_comment != NULL ? curbuf->b_oni_line_comment : (char_u *)"//";
   int commentlen = (int)STRLEN(comment);
-  const char_u* line = ml_get(lnum);
+  const char_u *line = ml_get(lnum);
   int linelen = (int)STRLEN(line);
   char_u *newp;
 
-  if (strstartswith(line, comment)) {
+  if (strstartswith(line, comment))
+  {
     // remove comment
 
     newp = alloc((linelen - commentlen) + 1);
 
     if (newp == NULL)
       return;
-      
+
     if (virtual_active() && curwin->w_cursor.coladd > 0)
       coladvance_force(getviscol());
 
     mch_memmove(newp, line + commentlen, (size_t)((linelen - commentlen) + 1));
     ml_replace(lnum, newp, FALSE);
     curwin->w_cursor.col -= commentlen;
-  } else {
+  }
+  else
+  {
     // add comment
 
     newp = alloc(linelen + commentlen + 1);
 
     if (newp == NULL)
       return;
-      
+
     if (virtual_active() && curwin->w_cursor.coladd > 0)
       coladvance_force(getviscol());
 
@@ -388,16 +392,19 @@ void toggle_comment(linenr_T lnum) {
   }
 }
 
-void toggle_comment_lines(linenr_T start, linenr_T end) {
+void toggle_comment_lines(linenr_T start, linenr_T end)
+{
   linenr_T lnum;
 
-  if (start > end) {
+  if (start > end)
+  {
     lnum = start;
     start = end;
     end = lnum;
   }
-  
-  for (lnum = start; lnum <= end; lnum++) {
+
+  for (lnum = start; lnum <= end; lnum++)
+  {
     toggle_comment(lnum);
   }
 }

--- a/src/normal.c
+++ b/src/normal.c
@@ -371,7 +371,6 @@ void toggle_comment(linenr_T lnum)
 
     mch_memmove(newp, line + commentlen, (size_t)((linelen - commentlen) + 1));
     ml_replace(lnum, newp, FALSE);
-    curwin->w_cursor.col -= commentlen;
   }
   else
   {
@@ -389,7 +388,6 @@ void toggle_comment(linenr_T lnum)
     mch_memmove(newp + commentlen, line, (size_t)(linelen + 1));
     ml_replace(lnum, newp, FALSE);
     inserted_bytes(lnum, 0, commentlen);
-    curwin->w_cursor.col += commentlen;
   }
 }
 
@@ -397,6 +395,7 @@ void toggle_comment_lines(linenr_T start, linenr_T end)
 {
   linenr_T lnum;
 
+  // if end is before start, normalize by swapping
   if (start > end)
   {
     lnum = start;
@@ -408,6 +407,10 @@ void toggle_comment_lines(linenr_T start, linenr_T end)
   {
     toggle_comment(lnum);
   }
+
+  // set cursoor to beginning
+  curwin->w_cursor.lnum = start;
+  curwin->w_cursor.col = 0;
 }
 
 /* Number of commands in nv_cmds[]. */

--- a/src/normal.c
+++ b/src/normal.c
@@ -402,6 +402,9 @@ void toggle_comment_lines(linenr_T start, linenr_T end)
     end = lnum;
   }
 
+  // save state for undo
+  u_save(start - 1, end + 1);
+
   for (lnum = start; lnum <= end; lnum++)
     toggle_comment(lnum);
 
@@ -409,6 +412,7 @@ void toggle_comment_lines(linenr_T start, linenr_T end)
   curwin->w_cursor.lnum = start;
   curwin->w_cursor.col = 0;
 
+  // mark dirty
   changed_lines(start, 0, end + 1, 0);
 }
 

--- a/src/ops.c
+++ b/src/ops.c
@@ -134,6 +134,7 @@ static char opchars[][3] = {
     {'g', '@', OPF_CHANGE},             // OP_FUNCTION
     {Ctrl_A, NUL, OPF_CHANGE},          // OP_NR_ADD
     {Ctrl_X, NUL, OPF_CHANGE},          // OP_NR_SUB
+    {'g', 'c', OPF_LINES | OPF_CHANGE}, // OP_COMMENT
 };
 
 /*

--- a/src/structs.h
+++ b/src/structs.h
@@ -458,19 +458,23 @@ struct u_header
 {
   /* The following have a pointer and a number. The number is used when
      * reading the undo file in u_read_undo() */
-  union {
+  union
+  {
     u_header_T *ptr; /* pointer to next undo header in list */
     long seq;
   } uh_next;
-  union {
+  union
+  {
     u_header_T *ptr; /* pointer to previous header in list */
     long seq;
   } uh_prev;
-  union {
+  union
+  {
     u_header_T *ptr; /* pointer to next header for alt. redo */
     long seq;
   } uh_alt_next;
-  union {
+  union
+  {
     u_header_T *ptr; /* pointer to previous header for alt. redo */
     long seq;
   } uh_alt_prev;
@@ -922,7 +926,8 @@ struct condstack
 {
   short cs_flags[CSTACK_LEN];  /* CSF_ flags */
   char cs_pending[CSTACK_LEN]; /* CSTP_: what's pending in ":finally"*/
-  union {
+  union
+  {
     void *csp_rv[CSTACK_LEN]; /* return typeval for pending return */
     void *csp_ex[CSTACK_LEN]; /* exception for pending throw */
   } cs_pend;
@@ -1030,7 +1035,8 @@ struct cleanup_stuff
 typedef struct attr_entry
 {
   short ae_attr; /* HL_BOLD, etc. */
-  union {
+  union
+  {
     struct
     {
       char_u *start; /* start escape sequence */
@@ -1296,7 +1302,8 @@ typedef struct
 {
   vartype_T v_type;
   char v_lock; /* see below: VAR_LOCKED, VAR_FIXED */
-  union {
+  union
+  {
     varnumber_T v_number; /* number value */
 #ifdef FEAT_FLOAT
     float_T v_float; /* floating number value */

--- a/src/structs.h
+++ b/src/structs.h
@@ -2372,6 +2372,8 @@ struct file_buffer
 #ifdef FEAT_DIFF
   int b_diff_failed; // internal diff failed for this buffer
 #endif
+
+  char_u *b_oni_line_comment;
 }; /* file_buffer */
 
 /* buffer updates */

--- a/src/structs.h
+++ b/src/structs.h
@@ -458,23 +458,19 @@ struct u_header
 {
   /* The following have a pointer and a number. The number is used when
      * reading the undo file in u_read_undo() */
-  union
-  {
+  union {
     u_header_T *ptr; /* pointer to next undo header in list */
     long seq;
   } uh_next;
-  union
-  {
+  union {
     u_header_T *ptr; /* pointer to previous header in list */
     long seq;
   } uh_prev;
-  union
-  {
+  union {
     u_header_T *ptr; /* pointer to next header for alt. redo */
     long seq;
   } uh_alt_next;
-  union
-  {
+  union {
     u_header_T *ptr; /* pointer to previous header for alt. redo */
     long seq;
   } uh_alt_prev;
@@ -926,8 +922,7 @@ struct condstack
 {
   short cs_flags[CSTACK_LEN];  /* CSF_ flags */
   char cs_pending[CSTACK_LEN]; /* CSTP_: what's pending in ":finally"*/
-  union
-  {
+  union {
     void *csp_rv[CSTACK_LEN]; /* return typeval for pending return */
     void *csp_ex[CSTACK_LEN]; /* exception for pending throw */
   } cs_pend;
@@ -1035,8 +1030,7 @@ struct cleanup_stuff
 typedef struct attr_entry
 {
   short ae_attr; /* HL_BOLD, etc. */
-  union
-  {
+  union {
     struct
     {
       char_u *start; /* start escape sequence */
@@ -1302,8 +1296,7 @@ typedef struct
 {
   vartype_T v_type;
   char v_lock; /* see below: VAR_LOCKED, VAR_FIXED */
-  union
-  {
+  union {
     varnumber_T v_number; /* number value */
 #ifdef FEAT_FLOAT
     float_T v_float; /* floating number value */

--- a/src/vim.h
+++ b/src/vim.h
@@ -1393,6 +1393,7 @@ typedef UINT32_TYPEDEF UINT32_T;
                               character (OP_ADD conflicts with Perl) */
 #define OP_NR_SUB 29       /* "<C-X>" Subtract from the number or \ \ \
                               alphabetic character */
+#define OP_COMMENT 30      /* "gc" and "gcc" toggles commented lines */
 
 /*
  * Motion types, used for operators and for yank/delete registers.


### PR DESCRIPTION
This adds a new operator, `gc`/`gcc`, which will comment or uncomment the current or selected lines. It also adds a new function to the API, `vimOptionSetLineComment` to specify the comment string that will be used for the current buffer.

The way it works is a bit crude currently, but it does the job. The comment string will only be inserted (and checked) at the very beginning of each line, ignoring indentation, and lines are commented or uncommented individually rather than as a block. If I can get a decent workflow going I might come back to this to give it some more polish. But until then it's fair game if anyone else wants a go at it.