### PR TITLE
Bugfix: Don't toggle comment on `Vc`

### DIFF
--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -288,6 +288,17 @@ MU_TEST(test_cursor_toggle_there_and_back_again_visual_multi)
   mu_check(vimCursorGetColumn() == 0);
 }
 
+MU_TEST(test_regression_Vc)
+{
+  vimInput("V");
+  vimInput("c");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: |%s|\n", line);
+
+  mu_check(strcmp(line, "") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -303,6 +314,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_undo_visual_multi);
   MU_RUN_TEST(test_cursor_toggle_there_and_back_again);
   MU_RUN_TEST(test_cursor_toggle_there_and_back_again_visual_multi);
+  MU_RUN_TEST(test_regression_Vc);
 }
 
 int main(int argc, char **argv)

--- a/src/normal.c
+++ b/src/normal.c
@@ -6758,7 +6758,7 @@ static void nv_redo(cmdarg_T *cap)
  */
 static void nv_Undo(cmdarg_T *cap)
 {
-  /* In Visual mode and typing "gUU" triggers an operator */
+  /* In Visual mode OR typing "gUU" triggers an operator */
   if (cap->oap->op_type == OP_UPPER || VIsual_active)
   {
     /* translate "gUU" to "gUgU" */
@@ -6778,8 +6778,8 @@ static void nv_Undo(cmdarg_T *cap)
  */
 static void nv_c(cmdarg_T *cap)
 {
-  /* In Visual mode and typing "gcc" triggers an operator */
-  if (cap->oap->op_type == OP_COMMENT || VIsual_active)
+  /* In Visual mode AND typing "gcc" triggers an operator */
+  if (cap->oap->op_type == OP_COMMENT && VIsual_active)
   {
     /* translate "gcc" to "gcgc" */
     cap->cmdchar = 'g';


### PR DESCRIPTION
**Issue:** Pressing `c` in visual mode comments out selected lines

**Defect:** Caused by a boolean or condition involving `VIsual_active` that should have been a boolean *and*. This might in turn have been caused, at least partly, by a misleading comment.

**Fix:** Switch the boolean _or_ to an _and_, and rectify the misleading comment.