### PR TITLE
feat(undo): Add sync API

### DIFF
--- a/src/apitest/undo_redo.c
+++ b/src/apitest/undo_redo.c
@@ -74,12 +74,66 @@ MU_TEST(test_multiple_undo_redo)
   mu_check(count == 1);
 }
 
+MU_TEST(test_undo_save)
+{
+  // Save buffer before changing
+
+  vimUndoSaveRegion(0, 3);
+
+  // Replace first line with 'one'
+  char_u *lines[] = {"one"};
+  vimBufferSetLines(curbuf, 0, 1, lines, 1);
+
+  vimUndoSaveRegion(0, 3);
+
+  char_u *linesAgain[] = {"two"};
+  vimBufferSetLines(curbuf, 0, 1, linesAgain, 1);
+
+  mu_check(vimBufferGetLineCount(curbuf) == 3);
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "two") == 0);
+
+  vimInput("u");
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1),
+                  "This is the first line of a test file") == 0);
+}
+
+MU_TEST(test_undo_sync)
+{
+  // Save buffer before changing
+
+  vimUndoSaveRegion(0, 3);
+
+  // Replace first line with 'one'
+  char_u *lines[] = {"one"};
+  vimBufferSetLines(curbuf, 0, 1, lines, 1);
+
+  // Create sync point (new undo level)
+  vimUndoSync(0);
+  vimUndoSaveRegion(0, 3);
+
+  char_u *linesAgain[] = {"two"};
+  vimBufferSetLines(curbuf, 0, 1, linesAgain, 1);
+
+  mu_check(vimBufferGetLineCount(curbuf) == 3);
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "two") == 0);
+
+  vimInput("u");
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1),
+                  "one") == 0);
+
+  vimInput("u");
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1),
+                  "This is the first line of a test file") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_multiple_undo);
   MU_RUN_TEST(test_multiple_undo_redo);
+  MU_RUN_TEST(test_undo_save);
+  MU_RUN_TEST(test_undo_sync);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -234,6 +234,11 @@ int vimUndoSaveRegion(linenr_T start_lnum, linenr_T end_lnum)
   return u_save(start_lnum, end_lnum);
 }
 
+void vimUndoSync(int force)
+{
+  u_sync(force);
+}
+
 int vimVisualGetType(void) { return VIsual_mode; }
 
 void vimVisualGetRange(pos_T *startPos, pos_T *endPos)

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -172,6 +172,14 @@ void vimRegisterGet(int reg_name, int *num_lines, char_u ***lines);
 int vimUndoSaveCursor(void);
 int vimUndoSaveRegion(linenr_T start_lnum, linenr_T end_lnum);
 
+/*
+ * vimUndoSync(force)
+ *
+ * Create a sync point (a new undo level) - stop adding to current
+ * undo entry, and start a new one.
+ */
+void vimUndoSync(int force);
+
 /***
  * Visual Mode
  ***/


### PR DESCRIPTION
This adds a `vimUndoSync` API to create a new undo group - needed for the format feature: https://github.com/onivim/oni2/pull/1903 to ensure formatting changes are properly undoable.