### PR TITLE
feat(api): Auto-indent provider callback

### DIFF
--- a/src/apitest/autoindent.c
+++ b/src/apitest/autoindent.c
@@ -44,7 +44,7 @@ void test_teardown(void) {}
 
 MU_TEST(test_autoindent_tab_normal_o)
 {
-  vimOptionSetInsertSpaces(false);
+  vimOptionSetInsertSpaces(FALSE);
   vimSetAutoIndentCallback(&alwaysIndent);
   vimInput("o");
   vimInput("a");
@@ -56,7 +56,7 @@ MU_TEST(test_autoindent_tab_normal_o)
 
 MU_TEST(test_autoindent_spaces_normal_o)
 {
-  vimOptionSetInsertSpaces(true);
+  vimOptionSetInsertSpaces(TRUE);
   vimOptionSetTabSize(7);
   vimSetAutoIndentCallback(&alwaysIndent);
   vimInput("o");
@@ -69,7 +69,7 @@ MU_TEST(test_autoindent_spaces_normal_o)
 
 MU_TEST(test_autounindent_spaces_normal_o)
 {
-  vimOptionSetInsertSpaces(true);
+  vimOptionSetInsertSpaces(TRUE);
   vimOptionSetTabSize(2);
   vimSetAutoIndentCallback(&alwaysUnindent);
   vimInput("o");
@@ -84,7 +84,7 @@ MU_TEST(test_autounindent_spaces_normal_o)
 
 MU_TEST(test_autounindent_spaces_no_indent)
 {
-  vimOptionSetInsertSpaces(true);
+  vimOptionSetInsertSpaces(TRUE);
   vimOptionSetTabSize(2);
   vimSetAutoIndentCallback(&alwaysUnindent);
   vimInput("A");
@@ -98,7 +98,7 @@ MU_TEST(test_autounindent_spaces_no_indent)
 
 MU_TEST(test_autoindent_tab_insert_cr)
 {
-  vimOptionSetInsertSpaces(false);
+  vimOptionSetInsertSpaces(FALSE);
   vimSetAutoIndentCallback(&alwaysIndent);
   vimInput("A");
   vimInput("<cr>");

--- a/src/apitest/autoindent.c
+++ b/src/apitest/autoindent.c
@@ -1,0 +1,89 @@
+#include "libvim.h"
+#include "minunit.h"
+
+static int indentSize = 0;
+
+int onIndent(int tabSize, int prevIndent, char_u *prevLine, char_u *line)
+{
+  printf("onIndent: ts: %d prevIndent: %d prev |%s| line: |%s|", tabSize, prevIndent, prevLine, line);
+
+  return indentSize;
+};
+
+void test_setup(void)
+{
+  vimInput("<Esc>");
+  vimInput("<Esc>");
+  vimExecute("e!");
+
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+/* TODO: Get this test green */
+/* MU_TEST(insert_count) { */
+/*   vimInput("5"); */
+/*   vimInput("i"); */
+/*   vimInput("a"); */
+/*   vimInput("\033"); */
+
+/*   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine()); */
+/*   printf("LINE: %s\n", line); */
+/*   mu_check(strcmp(line, "aaaaaThis is the first line of a test file") == 0);
+ */
+/* } */
+
+MU_TEST(test_autoindent_normal_o)
+{
+  indentSize = 3;
+  vimInput("o");
+  vimInput("a");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: |%s|\n", line);
+  char_u *line2 = "\t  a";
+  printf("c0: %d", line[0]);
+  printf("c1: %d", line[1]);
+  printf("c2: %d", line[2]);
+  printf("c3: %d", line[3]);
+  mu_check(strcmp(line, line2) == 0);
+}
+
+MU_TEST(test_autoindent_insert_cr)
+{
+  indentSize = 3;
+  vimInput("A");
+  vimInput("<cr>");
+  vimInput("a");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: |%s|\n", line);
+  char_u *line2 = "\t  a";
+  mu_check(strcmp(line, line2) == 0);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_autoindent_normal_o);
+  MU_RUN_TEST(test_autoindent_insert_cr);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+  //vimSetIndentationCallback(&onIndent);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/testfile.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/autoindent.c
+++ b/src/apitest/autoindent.c
@@ -1,17 +1,17 @@
 #include "libvim.h"
 #include "minunit.h"
 
-int alwaysIndent(int bufferid, char_u *prevLine, char_u *line)
+int alwaysIndent(buf_T *buf, char_u *prevLine, char_u *line)
 {
   return 1;
 }
 
-int alwaysUnindent(int bufferId, char_u *prevLine, char_u *line)
+int alwaysUnindent(buf_T *buf, char_u *prevLine, char_u *line)
 {
   return -1;
 }
 
-int neverIndent(int bufferId, char_u *prevLine, char_u *line)
+int neverIndent(buf_T *buf, char_u *prevLine, char_u *line)
 {
   return 0;
 }

--- a/src/change.c
+++ b/src/change.c
@@ -2099,7 +2099,7 @@ int open_line(
   {
     int sw = (int)get_sw_value(curbuf);
     int indentOption = autoIndentCallback(
-        curbuf->b_fnum,
+        curbuf,
         saved_line,
         next_line);
 

--- a/src/change.c
+++ b/src/change.c
@@ -1334,7 +1334,6 @@ int open_line(
     int flags,
     int second_line_indent)
 {
-  printf("open_line - 1\n");
   char_u *saved_line;       // copy of the original line
   char_u *next_line = NULL; // copy of the next line
   char_u *p_extra = NULL;   // what goes to next line
@@ -2096,11 +2095,9 @@ int open_line(
     did_append = FALSE;
   }
 
-  int sw = (int)get_sw_value(curbuf);
-  printf("shiftwidtH: %d\n", sw);
-
   if (autoIndentCallback != NULL)
   {
+    int sw = (int)get_sw_value(curbuf);
     int indentOption = autoIndentCallback(
         curbuf->b_fnum,
         saved_line,

--- a/src/change.c
+++ b/src/change.c
@@ -1334,6 +1334,7 @@ int open_line(
     int flags,
     int second_line_indent)
 {
+  printf("open_line - 1\n");
   char_u *saved_line;       // copy of the original line
   char_u *next_line = NULL; // copy of the next line
   char_u *p_extra = NULL;   // what goes to next line
@@ -2093,6 +2094,26 @@ int open_line(
     changed_bytes(curwin->w_cursor.lnum, 0);
     curwin->w_cursor.lnum--;
     did_append = FALSE;
+  }
+
+  int sw = (int)get_sw_value(curbuf);
+  printf("shiftwidtH: %d\n", sw);
+
+  if (autoIndentCallback != NULL)
+  {
+    int indentOption = autoIndentCallback(
+        curbuf->b_fnum,
+        saved_line,
+        next_line);
+
+    if (indentOption < 0 && newindent >= sw)
+    {
+      newindent -= sw;
+    }
+    else if (indentOption > 0)
+    {
+      newindent += sw;
+    }
   }
 
   if (newindent

--- a/src/globals.h
+++ b/src/globals.h
@@ -54,6 +54,7 @@ EXTERN FormatCallback formatCallback INIT(= NULL);
 EXTERN GotoCallback gotoCallback INIT(= NULL);
 EXTERN VoidCallback displayIntroCallback INIT(= NULL);
 EXTERN VoidCallback displayVersionCallback INIT(= NULL);
+EXTERN AutoIndentCallback autoIndentCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
 EXTERN QuitCallback quitCallback INIT(= NULL);
 EXTERN TerminalCallback terminalCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -117,6 +117,11 @@ void vimSetFileWriteFailureCallback(FileWriteFailureCallback f)
   fileWriteFailureCallback = f;
 }
 
+void vimSetAutoIndentCallback(AutoIndentCallback f)
+{
+  autoIndentCallback = f;
+}
+
 void vimSetMessageCallback(MessageCallback f)
 {
   messageCallback = f;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -112,6 +112,12 @@ void vimInput(char_u *input);
 void vimExecute(char_u *cmd);
 
 /***
+ * Auto-indent
+ ***/
+
+int vimSetAutoIndentCallback(AutoIndentCallback callback);
+
+/***
  * Messages
  ***/
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -118,7 +118,7 @@ typedef struct
 
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines, int *blockType /* MLINE, MCHAR, MBLOCK */);
 typedef void (*FormatCallback)(formatRequest_T *formatRequest);
-typedef int (*AutoIndentCallback)(buf_T* buf,
+typedef int (*AutoIndentCallback)(buf_T *buf,
                                   char_u *prevLine, char_u *currentLine);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);

--- a/src/structs.h
+++ b/src/structs.h
@@ -118,7 +118,7 @@ typedef struct
 
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines, int *blockType /* MLINE, MCHAR, MBLOCK */);
 typedef void (*FormatCallback)(formatRequest_T *formatRequest);
-typedef int (*AutoIndentCallback)(int bufferId,
+typedef int (*AutoIndentCallback)(buf_T* buf,
                                   char_u *prevLine, char_u *currentLine);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);

--- a/src/structs.h
+++ b/src/structs.h
@@ -118,6 +118,8 @@ typedef struct
 
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines, int *blockType /* MLINE, MCHAR, MBLOCK */);
 typedef void (*FormatCallback)(formatRequest_T *formatRequest);
+typedef int (*AutoIndentCallback)(int bufferId,
+                                  char_u *prevLine, char_u *currentLine);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);
 typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count);


### PR DESCRIPTION
This adds a hook for a custom C indent provider - given the current line, the previous line, and the buffer - the indent provider returns `1` if indentation should be increased, `-1` if indentation should be decreased, or `0` if it should remain the same.

This will allow us to set up Onivim 2 to hook into the indentation provider, given the indentation rules provided by VSCode extension language configuration, ie:
```
  "indentationRules": {
    "increaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$",
    "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*[\\}\\]].*$"
  }
```