### PR TITLE
feat(api): Autoindent - add `lnum` argument

### DIFF
--- a/src/apitest/autoindent.c
+++ b/src/apitest/autoindent.c
@@ -1,18 +1,26 @@
 #include "libvim.h"
 #include "minunit.h"
 
-int alwaysIndent(buf_T *buf, char_u *prevLine, char_u *line)
+static int lastLnum = -1;
+
+int alwaysIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *line)
 {
+  printf("alwaysIndent - lnum: %d\n", lnum);
+  lastLnum = lnum;
   return 1;
 }
 
-int alwaysUnindent(buf_T *buf, char_u *prevLine, char_u *line)
+int alwaysUnindent(int lnum, buf_T *buf, char_u *prevLine, char_u *line)
 {
+  printf("alwaysUnindent - lnum: %d\n", lnum);
+  lastLnum = lnum;
   return -1;
 }
 
-int neverIndent(buf_T *buf, char_u *prevLine, char_u *line)
+int neverIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *line)
 {
+  printf("neverIndent - lnum: %d\n", lnum);
+  lastLnum = lnum;
   return 0;
 }
 
@@ -52,6 +60,7 @@ MU_TEST(test_autoindent_tab_normal_o)
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   char_u *line2 = "\ta";
   mu_check(strcmp(line, line2) == 0);
+  mu_check(lastLnum == 2);
 }
 
 MU_TEST(test_autoindent_spaces_normal_o)
@@ -65,6 +74,7 @@ MU_TEST(test_autoindent_spaces_normal_o)
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   char_u *line2 = "       a";
   mu_check(strcmp(line, line2) == 0);
+  mu_check(lastLnum == 2);
 }
 
 MU_TEST(test_autounindent_spaces_normal_o)
@@ -80,6 +90,7 @@ MU_TEST(test_autounindent_spaces_normal_o)
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   char_u *line2 = "b";
   mu_check(strcmp(line, line2) == 0);
+  mu_check(lastLnum == 3);
 }
 
 MU_TEST(test_autounindent_spaces_no_indent)
@@ -94,6 +105,7 @@ MU_TEST(test_autounindent_spaces_no_indent)
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   char_u *line2 = "b";
   mu_check(strcmp(line, line2) == 0);
+  mu_check(lastLnum == 2);
 }
 
 MU_TEST(test_autoindent_tab_insert_cr)
@@ -110,6 +122,7 @@ MU_TEST(test_autoindent_tab_insert_cr)
   printf("LINE: |%s|\n", line);
   char_u *line3 = "\t\ta";
   mu_check(strcmp(line, line3) == 0);
+  mu_check(lastLnum == 3);
 }
 
 MU_TEST_SUITE(test_suite)

--- a/src/change.c
+++ b/src/change.c
@@ -2099,6 +2099,7 @@ int open_line(
   {
     int sw = (int)get_sw_value(curbuf);
     int indentOption = autoIndentCallback(
+        curwin->w_cursor.lnum + 1,
         curbuf,
         saved_line,
         next_line);

--- a/src/structs.h
+++ b/src/structs.h
@@ -118,7 +118,7 @@ typedef struct
 
 typedef int (*ClipboardGetCallback)(int regname, int *num_lines, char_u ***lines, int *blockType /* MLINE, MCHAR, MBLOCK */);
 typedef void (*FormatCallback)(formatRequest_T *formatRequest);
-typedef int (*AutoIndentCallback)(buf_T *buf,
+typedef int (*AutoIndentCallback)(int lnum, buf_T *buf,
                                   char_u *prevLine, char_u *currentLine);
 typedef void (*VoidCallback)(void);
 typedef void (*WindowSplitCallback)(windowSplit_T splitType, char_u *fname);


### PR DESCRIPTION
This updates the `autoIndentCallback` to also take the line number of the new line we're opening - this is because sometimes just the current line and previous line contents are not enough to determine indentation level. Passing the `lnum` allows us to query previous lines, too.