### PR TITLE
fix(api): Autoindent - Allow values greater than 1 and less than -1

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -2104,13 +2104,10 @@ int open_line(
         saved_line,
         next_line);
 
-    if (indentOption < 0 && newindent >= sw)
+    newindent += (indentOption * sw);
+    if (newindent < 0)
     {
-      newindent -= sw;
-    }
-    else if (indentOption > 0)
-    {
-      newindent += sw;
+      newindent = 0;
     }
   }
 


### PR DESCRIPTION
Currently, the auto-indent callback API only allows a single level of indentation change - but there are cases where we'd like to make greater changes in indentation.

This adjusts the auto-indent callback to support values greater than 1 and less than -1.