### PR TITLE
feat: add tabpage callback for :tab* commands

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6580,6 +6580,7 @@ static void
 ex_tabnext(exarg_T *eap)
 {
   int tab_number;
+  tabPageRequest_T tabPageRequest;
 
   if (NOT_IN_POPUP_WINDOW)
     return;
@@ -6625,6 +6626,22 @@ ex_tabnext(exarg_T *eap)
     break;
   default: /* CMD_tabnext */
     tab_number = get_tabpage_arg(eap);
+    
+    if (tabPageCallback != NULL)
+    {
+      if (tab_number == 0) {
+        tabPageRequest.kind = NEXT;
+      } else {
+        tabPageRequest.kind = GOTO;
+        tabPageRequest.arg = tab_number;
+      }
+      
+      if (tabPageCallback(tabPageRequest))
+      {
+        return;
+      }
+    }
+
     if (eap->errmsg == NULL)
       goto_tabpage(tab_number);
     break;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5784,6 +5784,7 @@ ex_tabclose(exarg_T *eap)
     
     if (tabPageCallback(tabPageRequest))
     {
+      eap->errmsg = NULL;
       return;
     }
   }
@@ -5830,6 +5831,7 @@ ex_tabonly(exarg_T *eap)
     
     if (tabPageCallback(tabPageRequest))
     {
+      eap->errmsg = NULL;
       return;
     }
   }
@@ -6638,6 +6640,7 @@ ex_tabnext(exarg_T *eap)
       
       if (tabPageCallback(tabPageRequest))
       {
+        eap->errmsg = NULL;
         return;
       }
     }
@@ -6664,6 +6667,7 @@ ex_tabmove(exarg_T *eap)
     
     if (tabPageCallback(tabPageRequest))
     {
+      eap->errmsg = NULL;
       return;
     }
   }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6639,10 +6639,18 @@ ex_tabnext(exarg_T *eap)
 static void
 ex_tabmove(exarg_T *eap)
 {
-  int tab_number;
+  int tab_number = get_tabpage_arg(eap);
+  tabPageRequest_T tabPageRequest;
+  int handled = 0;
 
-  tab_number = get_tabpage_arg(eap);
-  if (eap->errmsg == NULL)
+  if (tabPageCallback != NULL)
+  {
+    tabPageRequest.kind = MOVE;
+    tabPageRequest.arg = tab_number;
+    handled = tabPageCallback(tabPageRequest);
+  }
+
+  if (!handled && eap->errmsg == NULL)
     tabpage_move(tab_number);
 }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5781,7 +5781,7 @@ ex_tabclose(exarg_T *eap)
   {
     tabPageRequest.kind = CLOSE;
     tabPageRequest.arg = get_tabpage_arg(eap);
-    
+
     if (tabPageCallback(tabPageRequest))
     {
       eap->errmsg = NULL;
@@ -5828,7 +5828,7 @@ ex_tabonly(exarg_T *eap)
   {
     tabPageRequest.kind = CLOSE_OTHER;
     tabPageRequest.arg = get_tabpage_arg(eap);
-    
+
     if (tabPageCallback(tabPageRequest))
     {
       eap->errmsg = NULL;
@@ -6628,16 +6628,19 @@ ex_tabnext(exarg_T *eap)
     break;
   default: /* CMD_tabnext */
     tab_number = get_tabpage_arg(eap);
-    
+
     if (tabPageCallback != NULL)
     {
-      if (tab_number == 0) {
+      if (tab_number == 0)
+      {
         tabPageRequest.kind = NEXT;
-      } else {
+      }
+      else
+      {
         tabPageRequest.kind = GOTO;
         tabPageRequest.arg = tab_number;
       }
-      
+
       if (tabPageCallback(tabPageRequest))
       {
         eap->errmsg = NULL;
@@ -6664,7 +6667,7 @@ ex_tabmove(exarg_T *eap)
   {
     tabPageRequest.kind = MOVE;
     tabPageRequest.arg = tab_number;
-    
+
     if (tabPageCallback(tabPageRequest))
     {
       eap->errmsg = NULL;

--- a/src/globals.h
+++ b/src/globals.h
@@ -52,6 +52,7 @@ EXTERN FileWriteFailureCallback fileWriteFailureCallback INIT(= NULL);
 EXTERN DirectoryChangedCallback directoryChangedCallback INIT(= NULL);
 EXTERN FormatCallback formatCallback INIT(= NULL);
 EXTERN GotoCallback gotoCallback INIT(= NULL);
+EXTERN TabPageCallback tabPageCallback INIT(= NULL);
 EXTERN VoidCallback displayIntroCallback INIT(= NULL);
 EXTERN VoidCallback displayVersionCallback INIT(= NULL);
 EXTERN AutoIndentCallback autoIndentCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -448,6 +448,11 @@ void vimSetGotoCallback(GotoCallback callback)
   gotoCallback = callback;
 }
 
+void vimSetTabPageCallback(TabPageCallback callback)
+{
+  tabPageCallback = callback;
+}
+
 void vimSetDisplayIntroCallback(VoidCallback callback)
 {
   displayIntroCallback = callback;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -129,6 +129,7 @@ void vimSetMessageCallback(MessageCallback messageCallback);
 
 void vimSetFormatCallback(FormatCallback formatCallback);
 void vimSetGotoCallback(GotoCallback gotoCallback);
+void vimSetTabPageCallback(TabPageCallback tabPageCallback);
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
 
 /*

--- a/src/structs.h
+++ b/src/structs.h
@@ -97,6 +97,7 @@ typedef enum
   NEXT,
   MOVE,
   CLOSE,
+  CLOSE_OTHER,
 } tabPageKind_T;
 
 typedef struct

--- a/src/structs.h
+++ b/src/structs.h
@@ -82,12 +82,14 @@ typedef enum
   IMPLEMENTATION,
   TYPEDEFINITION,
   HOVER,
+  TABPAGE,
 } gotoTarget_T;
 
 typedef struct
 {
   pos_T location;
   gotoTarget_T target;
+  int count;
 } gotoRequest_T;
 
 typedef struct

--- a/src/structs.h
+++ b/src/structs.h
@@ -82,15 +82,28 @@ typedef enum
   IMPLEMENTATION,
   TYPEDEFINITION,
   HOVER,
-  TABPAGE,
 } gotoTarget_T;
 
 typedef struct
 {
   pos_T location;
   gotoTarget_T target;
-  int count;
 } gotoRequest_T;
+
+typedef enum
+{
+  GOTO,
+  PREVIOUS,
+  NEXT,
+  MOVE,
+  CLOSE,
+} tabPageKind_T;
+
+typedef struct
+{
+  tabPageKind_T kind;
+  int arg;
+} tabPageRequest_T;
 
 typedef struct
 {
@@ -128,6 +141,7 @@ typedef void (*WindowMovementCallback)(windowMovement_T movementType, int count)
 typedef void (*YankCallback)(yankInfo_T *yankInfo);
 typedef void (*TerminalCallback)(terminalRequest_t *terminalRequest);
 typedef int (*GotoCallback)(gotoRequest_T gotoInfo);
+typedef int (*TabPageCallback)(tabPageRequest_T tabPageInfo);
 
 typedef struct
 {

--- a/src/structs.h
+++ b/src/structs.h
@@ -93,17 +93,16 @@ typedef struct
 typedef enum
 {
   GOTO,
-  PREVIOUS,
-  NEXT,
   MOVE,
   CLOSE,
-  CLOSE_OTHER,
+  ONLY,
 } tabPageKind_T;
 
 typedef struct
 {
   tabPageKind_T kind;
-  int arg;
+  int arg;      // 0 means none, otherwise interpretation depends on [kind] and [relative]
+  int relative; // 0 means [arg] is absolute, otherwise [relative * arg] yields the actual relative position
 } tabPageRequest_T;
 
 typedef struct

--- a/src/window.c
+++ b/src/window.c
@@ -3927,16 +3927,20 @@ void goto_tabpage(int n)
   {
     if (n == 0)
     {
-      tabPageRequest.kind = NEXT;
+      tabPageRequest.kind = GOTO;
+      tabPageRequest.relative = 1;
+      tabPageRequest.arg = 1;
     }
     else if (n < 0)
     {
-      tabPageRequest.kind = PREVIOUS;
+      tabPageRequest.kind = GOTO;
+      tabPageRequest.relative = -1;
       tabPageRequest.arg = -n;
     }
     else
     {
       tabPageRequest.kind = GOTO;
+      tabPageRequest.relative = 0;
       tabPageRequest.arg = n;
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -3921,16 +3921,23 @@ void goto_tabpage(int n)
   tabpage_T *tp = NULL; // shut up compiler
   tabpage_T *ttp;
   int i;
-  gotoRequest_T gotoRequest;
+  tabPageRequest_T tabPageRequest;
 
-  gotoRequest.location = curwin->w_cursor;
-  gotoRequest.target = TABPAGE;
-  gotoRequest.count = n;
   int handled = 0;
 
-  if (gotoCallback != NULL)
+  if (tabPageCallback != NULL)
   {
-    handled = gotoCallback(gotoRequest);
+    if (n == 0) {
+      tabPageRequest.kind = NEXT;
+    } else if (n < 0) {
+      tabPageRequest.kind = PREVIOUS;
+      tabPageRequest.arg = -n;
+    } else {
+      tabPageRequest.kind = GOTO;
+      tabPageRequest.arg = n;
+    }
+
+    handled = tabPageCallback(tabPageRequest);
   }
 
   if (!handled)

--- a/src/window.c
+++ b/src/window.c
@@ -3925,12 +3925,17 @@ void goto_tabpage(int n)
 
   if (tabPageCallback != NULL)
   {
-    if (n == 0) {
+    if (n == 0)
+    {
       tabPageRequest.kind = NEXT;
-    } else if (n < 0) {
+    }
+    else if (n < 0)
+    {
       tabPageRequest.kind = PREVIOUS;
       tabPageRequest.arg = -n;
-    } else {
+    }
+    else
+    {
       tabPageRequest.kind = GOTO;
       tabPageRequest.arg = n;
     }

--- a/src/window.c
+++ b/src/window.c
@@ -3926,13 +3926,11 @@ void goto_tabpage(int n)
   if (tabPageCallback != NULL)
   {
     if (n == 0) {
-      printf("!! NEXT\n");
       tabPageRequest.kind = NEXT;
     } else if (n < 0) {
       tabPageRequest.kind = PREVIOUS;
       tabPageRequest.arg = -n;
     } else {
-      printf("!! GOTO\n");
       tabPageRequest.kind = GOTO;
       tabPageRequest.arg = n;
     }

--- a/src/window.c
+++ b/src/window.c
@@ -3921,61 +3921,75 @@ void goto_tabpage(int n)
   tabpage_T *tp = NULL; // shut up compiler
   tabpage_T *ttp;
   int i;
+  gotoRequest_T gotoRequest;
 
-  if (text_locked())
+  gotoRequest.location = curwin->w_cursor;
+  gotoRequest.target = TABPAGE;
+  gotoRequest.count = n;
+  int handled = 0;
+
+  if (gotoCallback != NULL)
   {
-    /* Not allowed when editing the command line. */
-    text_locked_msg();
-    return;
+    handled = gotoCallback(gotoRequest);
   }
 
-  /* If there is only one it can't work. */
-  if (first_tabpage->tp_next == NULL)
+  if (!handled)
   {
-    if (n > 1)
-      beep_flush();
-    return;
-  }
-
-  if (n == 0)
-  {
-    /* No count, go to next tab page, wrap around end. */
-    if (curtab->tp_next == NULL)
-      tp = first_tabpage;
-    else
-      tp = curtab->tp_next;
-  }
-  else if (n < 0)
-  {
-    /* "gT": go to previous tab page, wrap around end.  "N gT" repeats
-	 * this N times. */
-    ttp = curtab;
-    for (i = n; i < 0; ++i)
+    if (text_locked())
     {
-      for (tp = first_tabpage; tp->tp_next != ttp && tp->tp_next != NULL;
-           tp = tp->tp_next)
-        ;
-      ttp = tp;
-    }
-  }
-  else if (n == 9999)
-  {
-    /* Go to last tab page. */
-    for (tp = first_tabpage; tp->tp_next != NULL; tp = tp->tp_next)
-      ;
-  }
-  else
-  {
-    /* Go to tab page "n". */
-    tp = find_tabpage(n);
-    if (tp == NULL)
-    {
-      beep_flush();
+      /* Not allowed when editing the command line. */
+      text_locked_msg();
       return;
     }
-  }
 
-  goto_tabpage_tp(tp, TRUE, TRUE);
+    /* If there is only one it can't work. */
+    if (first_tabpage->tp_next == NULL)
+    {
+      if (n > 1)
+        beep_flush();
+      return;
+    }
+
+    if (n == 0)
+    {
+      /* No count, go to next tab page, wrap around end. */
+      if (curtab->tp_next == NULL)
+        tp = first_tabpage;
+      else
+        tp = curtab->tp_next;
+    }
+    else if (n < 0)
+    {
+      /* "gT": go to previous tab page, wrap around end.  "N gT" repeats
+     * this N times. */
+      ttp = curtab;
+      for (i = n; i < 0; ++i)
+      {
+        for (tp = first_tabpage; tp->tp_next != ttp && tp->tp_next != NULL;
+             tp = tp->tp_next)
+          ;
+        ttp = tp;
+      }
+    }
+    else if (n == 9999)
+    {
+      /* Go to last tab page. */
+      for (tp = first_tabpage; tp->tp_next != NULL; tp = tp->tp_next)
+        ;
+    }
+    else
+    {
+      /* Go to tab page "n". */
+      tp = find_tabpage(n);
+      if (tp == NULL)
+      {
+        beep_flush();
+        return;
+      }
+    }
+
+    goto_tabpage_tp(tp, TRUE, TRUE);
+  }
 }
 
 /*

--- a/src/window.c
+++ b/src/window.c
@@ -3923,80 +3923,80 @@ void goto_tabpage(int n)
   int i;
   tabPageRequest_T tabPageRequest;
 
-  int handled = 0;
-
   if (tabPageCallback != NULL)
   {
     if (n == 0) {
+      printf("!! NEXT\n");
       tabPageRequest.kind = NEXT;
     } else if (n < 0) {
       tabPageRequest.kind = PREVIOUS;
       tabPageRequest.arg = -n;
     } else {
+      printf("!! GOTO\n");
       tabPageRequest.kind = GOTO;
       tabPageRequest.arg = n;
     }
 
-    handled = tabPageCallback(tabPageRequest);
+    if (tabPageCallback(tabPageRequest))
+    {
+      return;
+    }
   }
 
-  if (!handled)
+  if (text_locked())
   {
-    if (text_locked())
-    {
-      /* Not allowed when editing the command line. */
-      text_locked_msg();
-      return;
-    }
-
-    /* If there is only one it can't work. */
-    if (first_tabpage->tp_next == NULL)
-    {
-      if (n > 1)
-        beep_flush();
-      return;
-    }
-
-    if (n == 0)
-    {
-      /* No count, go to next tab page, wrap around end. */
-      if (curtab->tp_next == NULL)
-        tp = first_tabpage;
-      else
-        tp = curtab->tp_next;
-    }
-    else if (n < 0)
-    {
-      /* "gT": go to previous tab page, wrap around end.  "N gT" repeats
-     * this N times. */
-      ttp = curtab;
-      for (i = n; i < 0; ++i)
-      {
-        for (tp = first_tabpage; tp->tp_next != ttp && tp->tp_next != NULL;
-             tp = tp->tp_next)
-          ;
-        ttp = tp;
-      }
-    }
-    else if (n == 9999)
-    {
-      /* Go to last tab page. */
-      for (tp = first_tabpage; tp->tp_next != NULL; tp = tp->tp_next)
-        ;
-    }
-    else
-    {
-      /* Go to tab page "n". */
-      tp = find_tabpage(n);
-      if (tp == NULL)
-      {
-        beep_flush();
-        return;
-      }
-    }
-
-    goto_tabpage_tp(tp, TRUE, TRUE);
+    /* Not allowed when editing the command line. */
+    text_locked_msg();
+    return;
   }
+
+  /* If there is only one it can't work. */
+  if (first_tabpage->tp_next == NULL)
+  {
+    if (n > 1)
+      beep_flush();
+    return;
+  }
+
+  if (n == 0)
+  {
+    /* No count, go to next tab page, wrap around end. */
+    if (curtab->tp_next == NULL)
+      tp = first_tabpage;
+    else
+      tp = curtab->tp_next;
+  }
+  else if (n < 0)
+  {
+    /* "gT": go to previous tab page, wrap around end.  "N gT" repeats
+   * this N times. */
+    ttp = curtab;
+    for (i = n; i < 0; ++i)
+    {
+      for (tp = first_tabpage; tp->tp_next != ttp && tp->tp_next != NULL;
+           tp = tp->tp_next)
+        ;
+      ttp = tp;
+    }
+  }
+  else if (n == 9999)
+  {
+    /* Go to last tab page. */
+    for (tp = first_tabpage; tp->tp_next != NULL; tp = tp->tp_next)
+      ;
+  }
+  else
+  {
+    /* Go to tab page "n". */
+    tp = find_tabpage(n);
+    if (tp == NULL)
+    {
+      beep_flush();
+      return;
+    }
+  }
+
+  goto_tabpage_tp(tp, TRUE, TRUE);
 }
 
 /*


### PR DESCRIPTION
This adds a tabpage callback that's called for the `:tab*` ex commands as well as `gt` and `gT`.

Status:

- [x] `gt`
- [x] `<N>gt`
- [x] `gT`
- [x] `<N>gT`
- [x] `:tabprevious`
- [x] `:tabprevious <N>`
- [x] `:tabnext`
- [x] `:tabnext <N>`
- [x] `:tabnext +/-<N>`
- [x] `:tabfirst`
- [x] `:tablast`
- [x] `:tabmove <N>`
- [x] `:tabmove +/-<N>`
- [x] `:tabclose`
- [x] `:tabclose <N>`
- [x] `:tabclose +/-<N>`
- [x] `:tabonly`
- [x] `:tabonly <N>`
- [x] `:tabonly +/-<N>`