### PR TITLE
fix: UTF-8 input failure for certain characters

### DIFF
--- a/src/apitest/abbrev.c
+++ b/src/apitest/abbrev.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<Esc>");
-  vimInput("<Esc>");
+  vimKey("<Esc>");
+  vimKey("<Esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/autocmds.c
+++ b/src/apitest/autocmds.c
@@ -27,8 +27,8 @@ int didEvent(event_T evt)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   reset();
@@ -41,7 +41,7 @@ MU_TEST(test_insertenter_insertleave)
   vimInput("i");
   mu_check(didEvent(EVENT_INSERTENTER));
 
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check(didEvent(EVENT_INSERTLEAVE));
 }
 

--- a/src/apitest/autoindent.c
+++ b/src/apitest/autoindent.c
@@ -40,8 +40,8 @@ int neverIndent(int lnum, buf_T *buf, char_u *prevLine, char_u *line)
 
 void test_setup(void)
 {
-  vimInput("<Esc>");
-  vimInput("<Esc>");
+  vimKey("<Esc>");
+  vimKey("<Esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -98,7 +98,7 @@ MU_TEST(test_autounindent_spaces_normal_o)
   vimSetAutoIndentCallback(&alwaysUnindent);
   vimInput("o");
   vimInput("  a");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("b");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
@@ -114,7 +114,7 @@ MU_TEST(test_autounindent_double_spaces_overflow_normal_o)
   vimSetAutoIndentCallback(&alwaysUnindentDouble);
   vimInput("o");
   vimInput("  a");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("b");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
@@ -130,7 +130,7 @@ MU_TEST(test_autounindent_double_spaces_normal_o)
   vimSetAutoIndentCallback(&alwaysUnindentDouble);
   vimInput("o");
   vimInput("    a");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("b");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
@@ -145,7 +145,7 @@ MU_TEST(test_autounindent_spaces_no_indent)
   vimOptionSetTabSize(2);
   vimSetAutoIndentCallback(&alwaysUnindent);
   vimInput("A");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("b");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
@@ -159,7 +159,7 @@ MU_TEST(test_autoindent_double_tab)
   vimOptionSetInsertSpaces(FALSE);
   vimSetAutoIndentCallback(&alwaysIndentDouble);
   vimInput("A");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("a");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
@@ -174,9 +174,9 @@ MU_TEST(test_autoindent_tab_insert_cr)
   vimOptionSetInsertSpaces(FALSE);
   vimSetAutoIndentCallback(&alwaysIndent);
   vimInput("A");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("a");
-  vimInput("<cr>");
+  vimKey("<cr>");
   vimInput("a");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());

--- a/src/apitest/backspace.c
+++ b/src/apitest/backspace.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<Esc>");
-  vimInput("<Esc>");
+  vimKey("<Esc>");
+  vimKey("<Esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -25,8 +25,8 @@ MU_TEST(backspace_beyond_insert)
   // Backspace a couple of times...
   // This verifies we have the correct backspace settings
   // (default doesn't backspace past insert region)
-  vimInput("<c-h>");
-  vimInput("<c-h>");
+  vimKey("<c-h>");
+  vimKey("<c-h>");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   printf("LINE: %s\n", line);

--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -25,8 +25,8 @@ void onAutoCommand(event_T command, buf_T *buf)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 }
@@ -42,7 +42,7 @@ MU_TEST(test_cmdline_esc)
 {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
@@ -50,7 +50,7 @@ MU_TEST(test_cmdline_enter)
 {
   vimInput(":");
   mu_check((vimGetMode() & CMDLINE) == CMDLINE);
-  vimInput("<cr>");
+  vimKey("<cr>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
@@ -91,7 +91,7 @@ MU_TEST(test_cmdline_no_execute_with_esc)
   vimInput(",");
   vimInput("2");
   vimInput("d");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 
   lc = vimBufferGetLineCount(buffer);
@@ -109,7 +109,7 @@ MU_TEST(test_cmdline_execute)
   vimInput(",");
   vimInput("2");
   vimInput("d");
-  vimInput("<cr>");
+  vimKey("<cr>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 
   lc = vimBufferGetLineCount(buffer);
@@ -130,7 +130,7 @@ MU_TEST(test_cmdline_substitution)
   vimInput("A");
   vimInput("!");
   vimInput("g");
-  vimInput("<cr>");
+  vimKey("<cr>");
 
   mu_check(strcmp(vimBufferGetLine(buffer, 1),
                   "Ahis is the first line of a test file") == 0);
@@ -140,15 +140,15 @@ MU_TEST(test_cmdline_get_type)
 {
   vimInput(":");
   mu_check(vimCommandLineGetType() == ':');
-  vimInput("<esc>");
+  vimKey("<esc>");
 
   vimInput("/");
   mu_check(vimCommandLineGetType() == '/');
-  vimInput("<esc>");
+  vimKey("<esc>");
 
   vimInput("?");
   mu_check(vimCommandLineGetType() == '?');
-  vimInput("<esc>");
+  vimKey("<esc>");
 }
 
 MU_TEST_SUITE(test_suite)

--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -74,7 +74,7 @@ MU_TEST(test_cmdline_autocmds)
   vimInput("c");
   mu_check(cmdLineChangedCount == 3);
   mu_check(cmdLineLeaveCount == 0);
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check(cmdLineLeaveCount == 1);
 
   mu_check((vimGetMode() & NORMAL) == NORMAL);

--- a/src/apitest/buffer_options.c
+++ b/src/apitest/buffer_options.c
@@ -42,8 +42,8 @@ void test_setup(void)
   vimBufferSetModifiable(curbuf, TRUE);
   vimBufferSetReadOnly(curbuf, FALSE);
 
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 

--- a/src/apitest/buffer_set_lines.c
+++ b/src/apitest/buffer_set_lines.c
@@ -19,8 +19,8 @@ void onBufferUpdate(bufferUpdate_T update)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 

--- a/src/apitest/buffer_updates.c
+++ b/src/apitest/buffer_updates.c
@@ -19,8 +19,8 @@ void onBufferUpdate(bufferUpdate_T update)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 
@@ -194,11 +194,11 @@ MU_TEST(test_reset_modified_after_undo)
   vimInput("a");
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "a") == 0);
 
-  vimInput("<esc>");
+  vimKey("<esc>");
   vimInput("u");
   mu_check(vimBufferGetModified(curbuf) == FALSE);
 
-  vimInput("<c-r>");
+  vimKey("<c-r>");
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "a") == 0);
   mu_check(vimBufferGetModified(curbuf) == TRUE);
 }

--- a/src/apitest/change_operator.c
+++ b/src/apitest/change_operator.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 
@@ -22,7 +22,7 @@ MU_TEST(test_change_word)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
 
   printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1),
@@ -35,7 +35,7 @@ MU_TEST(test_change_line_C)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
 
   printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
@@ -48,7 +48,7 @@ MU_TEST(test_change_line_c$)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
 
   printf("LINE: %s\n", vimBufferGetLine(curbuf, 1));
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
@@ -61,7 +61,7 @@ MU_TEST(test_change_redo)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
   vimInput("j");
   vimInput("_");
   vimInput(".");
@@ -81,7 +81,7 @@ MU_TEST(test_change_macro)
   vimInput("1");
   vimInput("2");
   vimInput("3");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
   vimInput("q");
 
   vimInput("j");

--- a/src/apitest/chdir.c
+++ b/src/apitest/chdir.c
@@ -19,8 +19,8 @@ void onDirectoryChanged(char_u *path)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/clipboard.c
+++ b/src/apitest/clipboard.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/cmdline_completion.c
+++ b/src/apitest/cmdline_completion.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 }
@@ -51,11 +51,11 @@ MU_TEST(test_cmdline_get_text)
   mu_check(strcmp(vimCommandLineGetText(), "abc") == 0);
   mu_check(vimCommandLineGetPosition() == 3);
 
-  vimInput("<c-h>");
+  vimKey("<c-h>");
   mu_check(strcmp(vimCommandLineGetText(), "ab") == 0);
   mu_check(vimCommandLineGetPosition() == 2);
 
-  vimInput("<cr>");
+  vimKey("<cr>");
 }
 
 MU_TEST(test_cmdline_completions)
@@ -151,29 +151,29 @@ MU_TEST(test_cmdline_completion_crash)
   vimInput("!m");
   vimInput(" ");
   vimInput("h");
-  vimInput("<LEFT>");
-  vimInput("<LEFT>");
+  vimKey("<LEFT>");
+  vimKey("<LEFT>");
 
   vimCommandLineGetCompletions(&completions, &count);
   FreeWild(count, completions);
   mu_check(count > -1);
 
-  vimInput("<LEFT>");
+  vimKey("<LEFT>");
   vimCommandLineGetCompletions(&completions, &count);
   FreeWild(count, completions);
   mu_check(count > -1);
 
-  vimInput("<RIGHT>");
+  vimKey("<RIGHT>");
   vimCommandLineGetCompletions(&completions, &count);
   FreeWild(count, completions);
   mu_check(count > -1);
 
-  vimInput("<RIGHT>");
+  vimKey("<RIGHT>");
   vimCommandLineGetCompletions(&completions, &count);
   FreeWild(count, completions);
   mu_check(count > -1);
 
-  vimInput("<RIGHT>");
+  vimKey("<RIGHT>");
   vimCommandLineGetCompletions(&completions, &count);
   FreeWild(count, completions);
   mu_check(count > -1);

--- a/src/apitest/cmdline_search.c
+++ b/src/apitest/cmdline_search.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");
@@ -26,7 +26,7 @@ MU_TEST(test_search_forward_esc)
   mu_check(vimCursorGetLine() == 1);
   mu_check(vimCursorGetColumn() == 17);
   mu_check(strcmp(vimSearchGetPattern(), "st") == 0);
-  vimInput("<cr>");
+  vimKey("<cr>");
 
   // Note - while in `incsearch`, the positions
   // returned match the END of the match.
@@ -81,12 +81,12 @@ MU_TEST(test_cancel_n)
   vimInput("/");
   vimInput("e");
   vimInput("s");
-  vimInput("<cr>");
+  vimKey("<cr>");
 
   // Create a new query, then cancel
   vimInput("/");
   vimInput("a");
-  vimInput("<c-c>");
+  vimKey("<c-c>");
 
   // n / N should use the previous query
   vimInput("n");

--- a/src/apitest/ctrl_g.c
+++ b/src/apitest/ctrl_g.c
@@ -23,8 +23,8 @@ void test_setup(void)
 {
   vimSetMessageCallback(&onMessage);
 
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 
@@ -36,7 +36,7 @@ void test_teardown(void) {}
 
 MU_TEST(test_fileinfo)
 {
-  vimInput("<c-g>");
+  vimKey("<c-g>");
 
   char_u *expected = "\"collateral/testfile.txt\" line 1 of 3 --33\%-- col 1";
   mu_check(strcmp(lastMessage, expected) == 0);

--- a/src/apitest/digraph.c
+++ b/src/apitest/digraph.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -20,7 +20,7 @@ MU_TEST(test_digraph_doesnt_hang)
 
   // Start inserting digraph... should be no-op right now
   // until we bring the feature back
-  vimInput("<c-k>");
+  vimKey("<c-k>");
 }
 
 MU_TEST_SUITE(test_suite)

--- a/src/apitest/dot_operator.c
+++ b/src/apitest/dot_operator.c
@@ -12,7 +12,7 @@ MU_TEST(test_basic_redo)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<esc>");
+  vimKey("<esc>");
 
   mu_check(strcmp(vimBufferGetLine(curbuf, 1), "abc") == 0);
 

--- a/src/apitest/eval.c
+++ b/src/apitest/eval.c
@@ -4,8 +4,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/external_messages.c
+++ b/src/apitest/external_messages.c
@@ -23,8 +23,8 @@ void onMessage(char_u *title, char_u *msg, msgPriority_T priority)
 void test_setup(void)
 {
   printf("a\n");
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   printf("b\n");
   vimExecute("e!");
   printf("e\n");

--- a/src/apitest/fileformats.c
+++ b/src/apitest/fileformats.c
@@ -7,8 +7,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/fileio.c
+++ b/src/apitest/fileio.c
@@ -40,8 +40,8 @@ void test_setup(void)
   strcpy(tempFile, tmp);
   vim_free(tmp);
 
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimBufferOpen(tempFile, 1, 0);
   vimExecute("e!");
 
@@ -119,7 +119,7 @@ MU_TEST(test_modify_file_externally)
 {
   vimInput("i");
   vimInput("a");
-  vimInput("<esc>");
+  vimKey("<esc>");
   vimExecute("w");
 
   // HACK: This sleep is required to get different 'mtimes'
@@ -168,7 +168,7 @@ MU_TEST(test_checkifchanged_updates_buffer)
   mu_check(vimBufferCheckIfChanged(curbuf) == 0);
   vimInput("i");
   vimInput("a");
-  vimInput("<esc>");
+  vimKey("<esc>");
   vimExecute("w");
 
   // HACK: This sleep is required to get different 'mtimes'
@@ -197,7 +197,7 @@ MU_TEST(test_checkifchanged_with_unsaved_changes)
   mu_check(vimBufferCheckIfChanged(curbuf) == 0);
   vimInput("i");
   vimInput("a");
-  vimInput("<esc>");
+  vimKey("<esc>");
   vimExecute("w");
 
   vimInput("i");

--- a/src/apitest/goto.c
+++ b/src/apitest/goto.c
@@ -19,8 +19,8 @@ void test_setup(void)
 {
   vimSetGotoCallback(&onGoto);
 
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 

--- a/src/apitest/indentation.c
+++ b/src/apitest/indentation.c
@@ -54,7 +54,8 @@ void test_teardown(void) {}
 
 MU_TEST(regression_test_no_crash_after_set_si)
 {
-  vimInput(":set si<CR>");
+  vimInput(":set si");
+  vimKey("<CR>");
   vimInput("o");
 
   mu_check(strcmp(vimBufferGetLine(curbuf, 2), "") == 0);

--- a/src/apitest/indentation.c
+++ b/src/apitest/indentation.c
@@ -41,8 +41,8 @@ void test_setup(void)
   vimExecute("setlocal formatprg&");
   vimExecute("set equalprg&");
 
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -82,7 +82,7 @@ MU_TEST(test_control_bracket)
 
   mu_check((vimGetMode() & INSERT) == INSERT);
 
-  vimInput("<c-[>");
+  vimKey("<c-[>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 

--- a/src/apitest/input.c
+++ b/src/apitest/input.c
@@ -10,8 +10,8 @@ void onUnhandledEscape(void)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -26,7 +26,7 @@ void test_teardown(void) {}
 MU_TEST(test_cmd_key_insert)
 {
   vimInput("o");
-  vimInput("<D-A>");
+  vimKey("<D-A>");
 
   mu_check(strcmp(vimBufferGetLine(curbuf, 2), "") == 0);
 }
@@ -36,7 +36,7 @@ MU_TEST(test_cmd_key_binding)
   vimExecute("inoremap <D-A> b");
 
   vimInput("o");
-  vimInput("<D-A>");
+  vimKey("<D-A>");
 
   mu_check(strcmp(vimBufferGetLine(curbuf, 2), "b") == 0);
 }
@@ -46,19 +46,19 @@ MU_TEST(test_arrow_keys_normal)
   mu_check(vimCursorGetLine() == 1);
   mu_check(vimCursorGetColumn() == 0);
 
-  vimInput("<Right>");
+  vimKey("<Right>");
   mu_check(vimCursorGetLine() == 1);
   mu_check(vimCursorGetColumn() == 1);
 
-  vimInput("<Down>");
+  vimKey("<Down>");
   mu_check(vimCursorGetLine() == 2);
   mu_check(vimCursorGetColumn() == 1);
 
-  vimInput("<Left>");
+  vimKey("<Left>");
   mu_check(vimCursorGetLine() == 2);
   mu_check(vimCursorGetColumn() == 0);
 
-  vimInput("<Up>");
+  vimKey("<Up>");
   mu_check(vimCursorGetLine() == 1);
   mu_check(vimCursorGetColumn() == 0);
 }
@@ -66,12 +66,12 @@ MU_TEST(test_arrow_keys_normal)
 MU_TEST(test_unhandled_escape)
 {
   // Should get unhandled escape...
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check(unhandledEscapeCount == 1);
 
   // ...but not if escape was handled
   vimInput("i");
-  vimInput("<esc>");
+  vimKey("<esc>");
   // Should still be 1 - no additional calls made.
   mu_check(unhandledEscapeCount == 1);
 }

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<Esc>");
-  vimInput("<Esc>");
+  vimKey("<Esc>");
+  vimKey("<Esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -45,7 +45,7 @@ MU_TEST(insert_cr)
   vimInput("a");
   vimInput("b");
   vimInput("c");
-  vimInput("<CR>");
+  vimKey("<CR>");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   mu_check(strcmp(line, "This is the first line of a test file") == 0);
@@ -126,7 +126,7 @@ MU_TEST(insert_mode_ctrlv)
   vimInput("O");
 
   // Character literal mode
-  vimInput("<c-v>");
+  vimKey("<c-v>");
 
   vimInput("1");
   vimInput("2");
@@ -143,7 +143,7 @@ MU_TEST(insert_mode_ctrlv_no_digit)
   vimInput("O");
 
   // Character literal mode
-  vimInput("<c-v>");
+  vimKey("<c-v>");
 
   // Jump out of character literal mode by entering a non-digit character
   vimInput("a");
@@ -159,13 +159,43 @@ MU_TEST(insert_mode_ctrlv_newline)
   vimInput("O");
 
   // Character literal mode
-  vimInput("<c-v>");
+  vimKey("<c-v>");
 
   // Jump out of character literal mode by entering a non-digit character
-  vimInput("<cr>");
+  vimKey("<cr>");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
   mu_check(line[0] == 13);
+}
+
+MU_TEST(insert_mode_utf8)
+{
+  vimInput("O");
+
+  // Character literal mode
+  vimInput("κόσμε");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "κόσμε") == 0);
+}
+
+// Regression test for onivim/oni2#1720
+MU_TEST(insert_mode_utf8_special_byte)
+{
+  vimInput("O");
+
+  u_char input[4];
+  input[0] = 232;
+  input[1] = 128;
+  input[2] = 133;
+  input[3] = 0;
+
+  vimInput(input);
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, input) == 0);
 }
 
 MU_TEST_SUITE(test_suite)
@@ -182,6 +212,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_mode_ctrlv);
   MU_RUN_TEST(insert_mode_ctrlv_no_digit);
   MU_RUN_TEST(insert_mode_ctrlv_newline);
+  MU_RUN_TEST(insert_mode_utf8);
+  MU_RUN_TEST(insert_mode_utf8_special_byte);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/jumplist.c
+++ b/src/apitest/jumplist.c
@@ -21,10 +21,10 @@ MU_TEST(test_jumplist_openfile)
 
   mu_check(curbuf == secondBuf);
 
-  vimInput("<c-o>");
+  vimKey("<c-o>");
   mu_check(curbuf == firstBuf);
 
-  vimInput("<c-i>");
+  vimKey("<c-i>");
   mu_check(curbuf == secondBuf);
 }
 
@@ -38,10 +38,10 @@ MU_TEST(test_jumplist_editnew)
   mu_check(firstBuf != secondBuf);
   mu_check(curbuf == secondBuf);
 
-  vimInput("<c-o>");
+  vimKey("<c-o>");
   mu_check(curbuf == firstBuf);
 
-  vimInput("<c-i>");
+  vimKey("<c-i>");
   mu_check(curbuf == secondBuf);
 }
 

--- a/src/apitest/macro_recording.c
+++ b/src/apitest/macro_recording.c
@@ -16,8 +16,8 @@ void onBufferUpdate(bufferUpdate_T update)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/matching_pair.c
+++ b/src/apitest/matching_pair.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 }

--- a/src/apitest/misc.c
+++ b/src/apitest/misc.c
@@ -16,8 +16,8 @@ void onVersion(void)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/normal_mode_curswant.c
+++ b/src/apitest/normal_mode_curswant.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/operator_pending.c
+++ b/src/apitest/operator_pending.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/option.c
+++ b/src/apitest/option.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -35,23 +35,23 @@ MU_TEST(test_insert_spaces)
   vimOptionSetInsertSpaces(TRUE);
 
   vimInput("I");
-  vimInput("<tab>");
+  vimKey("<tab>");
 
   char_u *line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "   Line 1") == 0);
 
-  vimInput("<bs>");
+  vimKey("<bs>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "Line 1") == 0);
 
   vimOptionSetTabSize(4);
 
-  vimInput("<tab>");
-  vimInput("<tab>");
+  vimKey("<tab>");
+  vimKey("<tab>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "        Line 1") == 0);
 
-  vimInput("<bs>");
+  vimKey("<bs>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "    Line 1") == 0);
 }
@@ -62,23 +62,23 @@ MU_TEST(test_insert_tabs)
   vimOptionSetInsertSpaces(FALSE);
 
   vimInput("I");
-  vimInput("<tab>");
+  vimKey("<tab>");
 
   char_u *line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "\tLine 1") == 0);
 
-  vimInput("<bs>");
+  vimKey("<bs>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "Line 1") == 0);
 
   vimOptionSetTabSize(4);
 
-  vimInput("<tab>");
-  vimInput("<tab>");
+  vimKey("<tab>");
+  vimKey("<tab>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "\t\tLine 1") == 0);
 
-  vimInput("<bs>");
+  vimKey("<bs>");
   line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "\tLine 1") == 0);
 }

--- a/src/apitest/registers.c
+++ b/src/apitest/registers.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -205,14 +205,14 @@ MU_TEST(test_ctrl_d)
   vimInput("g");
   printf("topline: %d\n", 1);
 
-  vimInput("<c-d>");
+  vimKey("<c-d>");
 
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 26);
 
   vimWindowSetHeight(12);
 
-  vimInput("<c-u>");
+  vimKey("<c-u>");
   mu_check(vimWindowGetTopLine() == 20);
 }
 
@@ -223,7 +223,7 @@ MU_TEST(test_ctrl_f)
   vimInput("g");
   printf("topline: %d\n", 1);
 
-  vimInput("<c-f>");
+  vimKey("<c-f>");
 
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 49);
@@ -232,18 +232,18 @@ MU_TEST(test_ctrl_f)
   // so the next <c-f> will be a partial scroll
   vimWindowSetHeight(20);
 
-  vimInput("<c-f>");
+  vimKey("<c-f>");
   // Partial scroll after resize
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 58);
 
   // Full scroll
-  vimInput("<c-f>");
+  vimKey("<c-f>");
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 76);
 
   // Full scroll
-  vimInput("<c-f>");
+  vimKey("<c-f>");
   printf("topline: %d\n", vimWindowGetTopLine());
   mu_check(vimWindowGetTopLine() == 94);
 }

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -11,7 +11,7 @@ void test_setup(void)
   vimInput(":");
   vimInput("5");
   vimInput("0");
-  vimInput("<cr>");
+  vimKey("<cr>");
 }
 
 void test_teardown(void) {}

--- a/src/apitest/search_highlights.c
+++ b/src/apitest/search_highlights.c
@@ -22,8 +22,8 @@ void onMessage(char_u *title, char_u *msg, msgPriority_T priority)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/search_large_file.c
+++ b/src/apitest/search_large_file.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
   vimInput("g");

--- a/src/apitest/terminal.c
+++ b/src/apitest/terminal.c
@@ -22,8 +22,8 @@ void onTerminal(terminalRequest_t *termRequest)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 }
@@ -38,12 +38,8 @@ void test_teardown(void)
 
 MU_TEST(test_term_noargs)
 {
-  vimInput(":");
-  vimInput("t");
-  vimInput("e");
-  vimInput("r");
-  vimInput("m");
-  vimInput("<cr>");
+  vimInput(":term");
+  vimKey("<cr>");
 
   mu_check(terminalCallCount == 1);
   mu_check(lastTerminalRequest.curwin == 0);
@@ -53,22 +49,8 @@ MU_TEST(test_term_noargs)
 
 MU_TEST(test_term_noclose)
 {
-  vimInput(":");
-  vimInput("t");
-  vimInput("e");
-  vimInput("r");
-  vimInput("m");
-  vimInput(" ");
-  vimInput("+");
-  vimInput("+");
-  vimInput("n");
-  vimInput("o");
-  vimInput("c");
-  vimInput("l");
-  vimInput("o");
-  vimInput("s");
-  vimInput("e");
-  vimInput("<cr>");
+  vimInput(":term ++noclose");
+  vimKey("<cr>");
 
   mu_check(terminalCallCount == 1);
   mu_check(lastTerminalRequest.curwin == 0);
@@ -78,17 +60,8 @@ MU_TEST(test_term_noclose)
 
 MU_TEST(test_term_bash)
 {
-  vimInput(":");
-  vimInput("t");
-  vimInput("e");
-  vimInput("r");
-  vimInput("m");
-  vimInput(" ");
-  vimInput("b");
-  vimInput("a");
-  vimInput("s");
-  vimInput("h");
-  vimInput("<cr>");
+  vimInput(":term bash");
+  vimKey("<cr>");
 
   mu_check(terminalCallCount == 1);
   mu_check(lastTerminalRequest.curwin == 0);
@@ -99,21 +72,8 @@ MU_TEST(test_term_bash)
 
 MU_TEST(test_term_curwin)
 {
-  vimInput(":");
-  vimInput("t");
-  vimInput("e");
-  vimInput("r");
-  vimInput("m");
-  vimInput(" ");
-  vimInput("+");
-  vimInput("+");
-  vimInput("c");
-  vimInput("u");
-  vimInput("r");
-  vimInput("w");
-  vimInput("i");
-  vimInput("n");
-  vimInput("<cr>");
+  vimInput(":term ++curwin");
+  vimKey("<cr>");
 
   mu_check(terminalCallCount == 1);
   mu_check(lastTerminalRequest.curwin == 1);

--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<Esc>");
-  vimInput("<Esc>");
+  vimKey("<Esc>");
+  vimKey("<Esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/apitest/undo_redo.c
+++ b/src/apitest/undo_redo.c
@@ -62,13 +62,13 @@ MU_TEST(test_multiple_undo_redo)
   vimInput("u");
 
   // Redo the last change
-  vimInput("<C-r>");
+  vimKey("<C-r>");
 
   count = vimBufferGetLineCount(cur);
   mu_check(count == 2);
 
   // Redo again
-  vimInput("<C-r>");
+  vimKey("<C-r>");
 
   count = vimBufferGetLineCount(cur);
   mu_check(count == 1);

--- a/src/apitest/visual_mode.c
+++ b/src/apitest/visual_mode.c
@@ -58,7 +58,7 @@ MU_TEST(test_characterwise_range)
   mu_check(end.lnum == 1);
   mu_check(end.col == 2);
 
-  vimInput("<esc>");
+  vimKey("<esc>");
   vimInput("j");
 
   // Validate we still get previous range
@@ -71,7 +71,7 @@ MU_TEST(test_characterwise_range)
 
 MU_TEST(test_ctrl_q)
 {
-  vimInput("<c-q>");
+  vimKey("<c-q>");
 
   mu_check((vimGetMode() & VISUAL) == VISUAL);
   mu_check(vimVisualGetType() == Ctrl_V);
@@ -80,7 +80,7 @@ MU_TEST(test_ctrl_q)
 
 MU_TEST(test_ctrl_Q)
 {
-  vimInput("<c-Q>");
+  vimKey("<c-Q>");
 
   mu_check((vimGetMode() & VISUAL) == VISUAL);
   mu_check(vimVisualGetType() == Ctrl_V);
@@ -89,7 +89,7 @@ MU_TEST(test_ctrl_Q)
 
 MU_TEST(test_insert_block_mode)
 {
-  vimInput("<c-v>");
+  vimKey("<c-v>");
   vimInput("j");
   vimInput("j");
   vimInput("j");
@@ -145,7 +145,7 @@ MU_TEST(test_change_block_mode_change)
   char_u *lines[] = {"line1", "line2", "line3", "line4", "line5"};
   vimBufferSetLines(curbuf, 0, 3, lines, 5);
 
-  vimInput("<c-v>");
+  vimKey("<c-v>");
   vimInput("j");
   vimInput("j");
   vimInput("j");
@@ -156,7 +156,7 @@ MU_TEST(test_change_block_mode_change)
   vimInput("b");
   vimInput("c");
 
-  vimInput("<esc>");
+  vimKey("<esc>");
 
   char_u *line = vimBufferGetLine(curbuf, 1);
   mu_check(strcmp(line, "abcine1") == 0);

--- a/src/apitest/visual_mode.c
+++ b/src/apitest/visual_mode.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimInput("g");
   vimInput("g");
@@ -22,16 +22,16 @@ MU_TEST(test_visual_is_active)
   mu_check(vimVisualIsActive() == 1);
   mu_check((vimGetMode() & VISUAL) == VISUAL);
 
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
   mu_check(vimVisualIsActive() == 0);
 
-  vimInput("<c-v>");
+  vimKey("<c-v>");
   mu_check(vimVisualGetType() == Ctrl_V);
   mu_check(vimVisualIsActive() == 1);
   mu_check((vimGetMode() & VISUAL) == VISUAL);
 
-  vimInput("<esc>");
+  vimKey("<esc>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
   mu_check(vimVisualIsActive() == 0);
 

--- a/src/apitest/visual_mode_operator.c
+++ b/src/apitest/visual_mode_operator.c
@@ -3,8 +3,8 @@
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
 
   vimExecute("e!");
 

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -30,8 +30,8 @@ void onWindowMovement(windowMovement_T movementType, int count)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");
@@ -60,7 +60,7 @@ MU_TEST(test_vsplit_ctrl_w)
 {
   vimBufferOpen("collateral/testfile.txt", 1, 0);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("v");
 
   mu_check(lastSplitType == VERTICAL_SPLIT);
@@ -71,7 +71,7 @@ MU_TEST(test_hsplit_ctrl_w)
 {
   vimBufferOpen("collateral/testfile.txt", 1, 0);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("s");
 
   mu_check(lastSplitType == HORIZONTAL_SPLIT);
@@ -90,44 +90,44 @@ MU_TEST(test_win_movements)
 {
 
   printf("Entering <c-w>\n");
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   printf("Entering <c-j>\n");
-  vimInput("<c-j>");
+  vimKey("<c-j>");
 
   mu_check(lastMovement == WIN_CURSOR_DOWN);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("k");
 
   mu_check(lastMovement == WIN_CURSOR_UP);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("h");
 
   mu_check(lastMovement == WIN_CURSOR_LEFT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("l");
 
   mu_check(lastMovement == WIN_CURSOR_RIGHT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("t");
 
   mu_check(lastMovement == WIN_CURSOR_TOP_LEFT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("b");
 
   mu_check(lastMovement == WIN_CURSOR_BOTTOM_RIGHT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("p");
 
   mu_check(lastMovement == WIN_CURSOR_PREVIOUS);
@@ -137,7 +137,7 @@ MU_TEST(test_win_movements)
 MU_TEST(test_win_move_count_before)
 {
   vimInput("2");
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("k");
 
   mu_check(lastMovement == WIN_CURSOR_UP);

--- a/src/apitest/window_splits.c
+++ b/src/apitest/window_splits.c
@@ -146,7 +146,7 @@ MU_TEST(test_win_move_count_before)
 
 MU_TEST(test_win_move_count_after)
 {
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("4");
   vimInput("k");
 
@@ -157,7 +157,7 @@ MU_TEST(test_win_move_count_after)
 MU_TEST(test_win_move_count_before_and_after)
 {
   vimInput("3");
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("5");
   vimInput("k");
 
@@ -167,36 +167,36 @@ MU_TEST(test_win_move_count_before_and_after)
 
 MU_TEST(test_move_commands)
 {
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("H");
   mu_check(lastMovement == WIN_MOVE_FULL_LEFT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("L");
 
   mu_check(lastMovement == WIN_MOVE_FULL_RIGHT);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("K");
 
   mu_check(lastMovement == WIN_MOVE_FULL_UP);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("J");
 
   mu_check(lastMovement == WIN_MOVE_FULL_DOWN);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("r");
 
   mu_check(lastMovement == WIN_MOVE_ROTATE_DOWNWARDS);
   mu_check(lastMovementCount == 1);
 
-  vimInput("<c-w>");
+  vimKey("<c-w>");
   vimInput("R");
 
   mu_check(lastMovement == WIN_MOVE_ROTATE_UPWARDS);

--- a/src/apitest/yank.c
+++ b/src/apitest/yank.c
@@ -54,8 +54,8 @@ void onYank(yankInfo_T *yankInfo)
 
 void test_setup(void)
 {
-  vimInput("<esc>");
-  vimInput("<esc>");
+  vimKey("<esc>");
+  vimKey("<esc>");
   vimExecute("e!");
 
   vimInput("g");

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -119,8 +119,32 @@ void vimSetFileWriteFailureCallback(FileWriteFailureCallback fileWriteFailureCal
 /***
  * User Input
  ***/
+
+/***
+ * vimInput
+ *
+ * vimInput(input) passes the string, verbatim, to vim to be processed,
+ * without replacing term-codes. This means strings like "<LEFT>" are 
+ * handled literally. This function handles Unicode text correctly.
+ */
 void vimInput(char_u *input);
 
+/***
+ * vimKey
+ *
+ * vimKey(input) passes a string and escapes termcodes - so a 
+ * a string like "<LEFT>" will first be replaced with the appropriate
+ * term-code, and handled.
+ */
+void vimKey(char_u *key);
+
+/***
+ * vimExecute
+ *
+ * vimExecute(cmd) executes a command as if it was typed at the command-line.
+ *
+ * Example: vimExecute("echo 'hello!');
+ */
 void vimExecute(char_u *cmd);
 
 /***


### PR DESCRIPTION
This is the `libvim`-side fix for https://github.com/onivim/oni2/issues/1720

For a character like `者`, which is a 3-byte UTF-8 character, with bytes (232, 128, 133), it would get expanded by the `replace_termcodes` call to (232, 128, 254, 88, 133). This is due to special handling around the `128` byte - it gets expanded via `K_SPECIAL` to its own 3-byte sequences.

This only affected a subset of UTF-8 characters - ones without a `0x80`/`128` byte would not be impacted by this replacement.

This breaks my assumption that `replace_termcodes` is safe for arbitrary Unicode values - so I split the `vimInput` API into two APIs:
- `vimInput` - pass the characters w/o `replace_termcodes`. Safe for Unicode, but does not handle keys like `<LEFT>`, `<ESC>`, `<CR>`, etc.
- `vimKey` - pass the characters into `replace_termcodes`. Not safe for Unicode, but handles keys like `<LEFT>`, etc.