### PR TITLE
fix(api/#163): Part 1: Add an API to get pending operator information

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,16 +46,6 @@ jobs:
     parameters:
         testRunner: run-tests.sh
 
-- job: Linux
-  displayName: "Linux - Ubuntu 16.04"
-  pool:
-    vmImage: 'Ubuntu 16.04'
-  steps:
-  - template: .ci/esy-build-steps.yml
-  - template: .ci/libvim-test.yml
-    parameters:
-        testRunner: run-tests.sh
-
 - job: MacOS14
   displayName: "MacOS Mojave"
   pool:

--- a/src/apitest/operator_pending.c
+++ b/src/apitest/operator_pending.c
@@ -107,6 +107,18 @@ MU_TEST(test_pending_operator_comment)
   mu_check(pendingOp.op_type == OP_COMMENT);
 }
 
+MU_TEST(test_pending_operator_register)
+{
+  vimInput("\"");
+  vimInput("a");
+  vimInput("y");
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == TRUE);
+  mu_check(pendingOp.op_type == OP_YANK);
+  mu_check(pendingOp.regname == 'a');
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -119,6 +131,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_pending_operator_delete_count);
   MU_RUN_TEST(test_pending_operator_change);
   MU_RUN_TEST(test_pending_operator_comment);
+  MU_RUN_TEST(test_pending_operator_register);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/operator_pending.c
+++ b/src/apitest/operator_pending.c
@@ -33,11 +33,92 @@ MU_TEST(test_delete_operator_pending)
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 }
 
+MU_TEST(test_pending_operator_insert)
+{
+  vimInput("i");
+
+  mu_check((vimGetMode() & INSERT) == INSERT);
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == FALSE);
+}
+
+MU_TEST(test_pending_operator_cmdline)
+{
+  vimInput(":");
+
+  mu_check((vimGetMode() & CMDLINE) == CMDLINE);
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == FALSE);
+}
+
+MU_TEST(test_pending_operator_visual)
+{
+  vimInput("v");
+
+  mu_check((vimGetMode() & VISUAL) == VISUAL);
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == FALSE);
+}
+
+MU_TEST(test_pending_operator_delete)
+{
+  vimInput("d");
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == TRUE);
+  mu_check(pendingOp.op_type == OP_DELETE);
+  mu_check(pendingOp.count == 0);
+}
+
+MU_TEST(test_pending_operator_delete_count)
+{
+  vimInput("5");
+  vimInput("d");
+
+  //mu_check((vimGetMode() & VISUAL) == VISUAL);
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == TRUE);
+  mu_check(pendingOp.op_type == OP_DELETE);
+  mu_check(pendingOp.count == 5);
+}
+
+MU_TEST(test_pending_operator_change)
+{
+  vimInput("2");
+  vimInput("c");
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == TRUE);
+  mu_check(pendingOp.op_type == OP_CHANGE);
+  mu_check(pendingOp.count == 2);
+}
+
+MU_TEST(test_pending_operator_comment)
+{
+  vimInput("g");
+  vimInput("c");
+
+  pendingOp_T pendingOp;
+  mu_check(vimGetPendingOperator(&pendingOp) == TRUE);
+  mu_check(pendingOp.op_type == OP_COMMENT);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_delete_operator_pending);
+  MU_RUN_TEST(test_pending_operator_insert);
+  MU_RUN_TEST(test_pending_operator_cmdline);
+  MU_RUN_TEST(test_pending_operator_visual);
+  MU_RUN_TEST(test_pending_operator_delete);
+  MU_RUN_TEST(test_pending_operator_delete_count);
+  MU_RUN_TEST(test_pending_operator_change);
+  MU_RUN_TEST(test_pending_operator_comment);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -460,6 +460,11 @@ void vimSetClipboardGetCallback(ClipboardGetCallback callback)
 
 int vimGetMode(void) { return get_real_state(); }
 
+int vimGetPendingOperator(pendingOp_T *pendingOp)
+{
+  return sm_get_pending_operator(pendingOp);
+}
+
 void vimSetFormatCallback(FormatCallback callback)
 {
   formatCallback = callback;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -300,6 +300,7 @@ void vimSetWindowMovementCallback(WindowMovementCallback callback);
 void vimSetClipboardGetCallback(ClipboardGetCallback callback);
 
 int vimGetMode(void);
+int vimGetPendingOperator(pendingOp_T *pendingOp);
 
 void vimSetYankCallback(YankCallback callback);
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -619,6 +619,32 @@ void *state_normal_cmd_initialize()
   return context;
 }
 
+int state_normal_pending_operator(void *ctx, pendingOp_T *pendingOp)
+{
+  if (ctx == NULL)
+  {
+    return FALSE;
+  }
+
+  normalCmd_T *context = (normalCmd_T *)ctx;
+
+  if (context->oap == NULL)
+  {
+    return FALSE;
+  }
+
+  if (context->oap->op_type == OP_NOP)
+  {
+    return FALSE;
+  }
+
+  pendingOp->op_type = context->oap->op_type;
+  pendingOp->regname = context->oap->regname;
+  pendingOp->count = context->ca.opcount;
+
+  return TRUE;
+}
+
 void state_normal_cmd_cleanup(void *ctx)
 {
   normalCmd_T *context = (normalCmd_T *)ctx;

--- a/src/proto/normal.pro
+++ b/src/proto/normal.pro
@@ -3,6 +3,7 @@
 void *state_normal_cmd_initialize();
 void state_normal_cmd_cleanup(void *ctx);
 executionStatus_T state_normal_cmd_execute(void *ctx, int key);
+int state_normal_pending_operator(void *ctx, pendingOp_T *pendingOp);
 
 void init_normal_cmds(void);
 void normal_cmd(oparg_T *oap, int toplevel);

--- a/src/proto/state_machine.pro
+++ b/src/proto/state_machine.pro
@@ -1,6 +1,7 @@
 /* state_machine.c */
 
 void sm_push(int mode, void *context, state_execute executeFn,
+             state_pending_operator pendingOperatorFn,
              state_cleanup cleanupFn);
 
 void sm_push_insert(int cmdchar, int startln, long count);
@@ -13,6 +14,7 @@ void sm_execute_normal(char_u *keys);
 void sm_execute(char_u *key);
 
 int sm_get_current_mode(void);
+int sm_get_pending_operator(pendingOp_T *pendingOp);
 
 sm_T *sm_get_current(void);
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -163,21 +163,6 @@ typedef enum
   COMPLETED_UNHANDLED,
 } executionStatus_T;
 
-typedef executionStatus_T (*state_execute)(void *context, int key);
-typedef void (*state_cleanup)(void *context);
-
-typedef const char *sname;
-
-/* State machine information */
-typedef struct
-{
-  void *context;
-  int mode;
-  state_execute execute_fn;
-  state_cleanup cleanup_fn;
-  void *prev;
-} sm_T;
-
 /*
  * Same, but without coladd.
  */
@@ -2966,6 +2951,30 @@ typedef struct cmdarg_S
   int retval;        /* return: CA_* values */
   char_u *searchbuf; /* return: pointer to search pattern or NULL */
 } cmdarg_T;
+
+typedef struct pendingOp_S
+{
+  int op_type;
+  int regname;
+  long count;
+} pendingOp_T;
+
+typedef executionStatus_T (*state_execute)(void *context, int key);
+typedef void (*state_cleanup)(void *context);
+typedef int (*state_pending_operator)(void *context, pendingOp_T *pendingOp);
+
+typedef const char *sname;
+
+/* State machine information */
+typedef struct
+{
+  void *context;
+  int mode;
+  state_execute execute_fn;
+  state_cleanup cleanup_fn;
+  state_pending_operator pending_operator_fn;
+  void *prev;
+} sm_T;
 
 /* values for retval: */
 #define CA_COMMAND_BUSY 1  /* skip restarting edit() once */


### PR DESCRIPTION
This adds an API to get the current pending-operator information (what operator is pending, any associated register, and count). This is part of a fix for #163 - there are still some items that would be useful that this doesn't provide (ie, typed characters _prior_ to an operator becoming active).