### PR TITLE
feat(api): Add an option-set callback for synchronizing config

### DIFF
--- a/src/apitest/option.c
+++ b/src/apitest/option.c
@@ -6,11 +6,23 @@ optionSet_T lastOptionSet;
 
 void onOptionSet(optionSet_T *options)
 {
+  if (lastOptionSet.stringval != NULL)
+  {
+    vim_free(lastOptionSet.stringval);
+  }
+
   lastOptionSet.fullname = options->fullname;
   lastOptionSet.shortname = options->shortname;
   lastOptionSet.type = options->type;
   lastOptionSet.numval = options->numval;
-  lastOptionSet.stringval = options->stringval;
+  if (options->stringval != NULL)
+  {
+    lastOptionSet.stringval = vim_strsave(options->stringval);
+  }
+  else
+  {
+    lastOptionSet.stringval = NULL;
+  }
   lastOptionSet.hidden = options->hidden;
   optionSetCount++;
 }

--- a/src/apitest/option.c
+++ b/src/apitest/option.c
@@ -1,6 +1,20 @@
 #include "libvim.h"
 #include "minunit.h"
 
+int optionSetCount = 0;
+optionSet_T lastOptionSet;
+
+void onOptionSet(optionSet_T *options)
+{
+  lastOptionSet.fullname = options->fullname;
+  lastOptionSet.shortname = options->shortname;
+  lastOptionSet.type = options->type;
+  lastOptionSet.numval = options->numval;
+  lastOptionSet.stringval = options->stringval;
+  lastOptionSet.hidden = options->hidden;
+  optionSetCount++;
+}
+
 void test_setup(void)
 {
   vimKey("<esc>");
@@ -10,6 +24,7 @@ void test_setup(void)
   vimInput("g");
   vimInput("g");
   vimInput("0");
+  optionSetCount = 0;
 }
 
 void test_teardown(void) {}
@@ -102,6 +117,51 @@ MU_TEST(test_encoding_cannot_change)
   mu_check(strcmp(p_enc, "utf-8") == 0);
 }
 
+MU_TEST(test_opt_relative_number)
+{
+  vimExecute("set rnu");
+  mu_check(optionSetCount == 1);
+  mu_check(strcmp(lastOptionSet.fullname, "relativenumber") == 0);
+  mu_check(strcmp(lastOptionSet.shortname, "rnu") == 0);
+  mu_check(lastOptionSet.numval == 1);
+
+  vimExecute("set nornu");
+  mu_check(optionSetCount == 2);
+  mu_check(strcmp(lastOptionSet.fullname, "relativenumber") == 0);
+  mu_check(strcmp(lastOptionSet.shortname, "rnu") == 0);
+  mu_check(lastOptionSet.numval == 0);
+}
+
+MU_TEST(test_opt_minimap)
+{
+  vimExecute("set minimap");
+  mu_check(optionSetCount == 1);
+  mu_check(strcmp(lastOptionSet.fullname, "minimap") == 0);
+  mu_check(lastOptionSet.shortname == NULL);
+  mu_check(lastOptionSet.numval == 1);
+
+  vimExecute("set nominimap");
+  mu_check(optionSetCount == 2);
+  mu_check(strcmp(lastOptionSet.fullname, "minimap") == 0);
+  mu_check(lastOptionSet.shortname == NULL);
+  mu_check(lastOptionSet.numval == 0);
+}
+
+MU_TEST(test_opt_smoothscroll)
+{
+  vimExecute("set smoothscroll");
+  mu_check(optionSetCount == 1);
+  mu_check(strcmp(lastOptionSet.fullname, "smoothscroll") == 0);
+  mu_check(lastOptionSet.shortname == NULL);
+  mu_check(lastOptionSet.numval == 1);
+
+  vimExecute("set nosmoothscroll");
+  mu_check(optionSetCount == 2);
+  mu_check(strcmp(lastOptionSet.fullname, "smoothscroll") == 0);
+  mu_check(lastOptionSet.shortname == NULL);
+  mu_check(lastOptionSet.numval == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -111,12 +171,16 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_insert_tabs);
   MU_RUN_TEST(test_tab_size);
   MU_RUN_TEST(test_encoding_cannot_change);
+  MU_RUN_TEST(test_opt_relative_number);
+  MU_RUN_TEST(test_opt_minimap);
+  MU_RUN_TEST(test_opt_smoothscroll);
 }
 
 int main(int argc, char **argv)
 {
   vimInit(argc, argv);
 
+  vimSetOptionSetCallback(&onOptionSet);
   vimBufferOpen("collateral/lines_100.txt", 1, 0);
 
   MU_RUN_SUITE(test_suite);

--- a/src/apitest/option.c
+++ b/src/apitest/option.c
@@ -124,12 +124,14 @@ MU_TEST(test_opt_relative_number)
   mu_check(strcmp(lastOptionSet.fullname, "relativenumber") == 0);
   mu_check(strcmp(lastOptionSet.shortname, "rnu") == 0);
   mu_check(lastOptionSet.numval == 1);
+  mu_check(lastOptionSet.type == 1);
 
   vimExecute("set nornu");
   mu_check(optionSetCount == 2);
   mu_check(strcmp(lastOptionSet.fullname, "relativenumber") == 0);
   mu_check(strcmp(lastOptionSet.shortname, "rnu") == 0);
   mu_check(lastOptionSet.numval == 0);
+  mu_check(lastOptionSet.type == 1);
 }
 
 MU_TEST(test_opt_minimap)
@@ -139,12 +141,14 @@ MU_TEST(test_opt_minimap)
   mu_check(strcmp(lastOptionSet.fullname, "minimap") == 0);
   mu_check(lastOptionSet.shortname == NULL);
   mu_check(lastOptionSet.numval == 1);
+  mu_check(lastOptionSet.type == 1);
 
   vimExecute("set nominimap");
   mu_check(optionSetCount == 2);
   mu_check(strcmp(lastOptionSet.fullname, "minimap") == 0);
   mu_check(lastOptionSet.shortname == NULL);
   mu_check(lastOptionSet.numval == 0);
+  mu_check(lastOptionSet.type == 1);
 }
 
 MU_TEST(test_opt_smoothscroll)
@@ -154,12 +158,24 @@ MU_TEST(test_opt_smoothscroll)
   mu_check(strcmp(lastOptionSet.fullname, "smoothscroll") == 0);
   mu_check(lastOptionSet.shortname == NULL);
   mu_check(lastOptionSet.numval == 1);
+  mu_check(lastOptionSet.type == 1);
 
   vimExecute("set nosmoothscroll");
   mu_check(optionSetCount == 2);
   mu_check(strcmp(lastOptionSet.fullname, "smoothscroll") == 0);
   mu_check(lastOptionSet.shortname == NULL);
   mu_check(lastOptionSet.numval == 0);
+  mu_check(lastOptionSet.type == 1);
+}
+
+MU_TEST(test_opt_runtimepath)
+{
+  vimExecute("set runtimepath=abc");
+  mu_check(optionSetCount == 1);
+  mu_check(strcmp(lastOptionSet.fullname, "runtimepath") == 0);
+  mu_check(strcmp(lastOptionSet.shortname, "rtp") == 0);
+  mu_check(strcmp(lastOptionSet.stringval, "abc") == 0);
+  mu_check(lastOptionSet.type == 0);
 }
 
 MU_TEST_SUITE(test_suite)
@@ -174,6 +190,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_opt_relative_number);
   MU_RUN_TEST(test_opt_minimap);
   MU_RUN_TEST(test_opt_smoothscroll);
+  MU_RUN_TEST(test_opt_runtimepath);
 }
 
 int main(int argc, char **argv)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6042,6 +6042,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_LIBCALL
     "libcall",
 #endif
+    "libvim",
 #ifdef FEAT_LINEBREAK
     "linebreak",
 #endif
@@ -6078,6 +6079,10 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_OLE
     "ole",
 #endif
+    "oni",
+    "oni2",
+    "onivim",
+    "onivim2",
 #ifdef FEAT_EVAL
     "packages",
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -57,6 +57,7 @@ EXTERN VoidCallback displayIntroCallback INIT(= NULL);
 EXTERN VoidCallback displayVersionCallback INIT(= NULL);
 EXTERN AutoIndentCallback autoIndentCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
+EXTERN OptionSetCallback optionSetCallback INIT(= NULL);
 EXTERN QuitCallback quitCallback INIT(= NULL);
 EXTERN TerminalCallback terminalCallback INIT(= NULL);
 EXTERN VoidCallback stopSearchHighlightCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -147,6 +147,11 @@ void vimSetDirectoryChangedCallback(DirectoryChangedCallback f)
   directoryChangedCallback = f;
 }
 
+void vimSetOptionSetCallback(OptionSetCallback f)
+{
+  optionSetCallback = f;
+}
+
 void vimSetQuitCallback(QuitCallback f)
 {
   quitCallback = f;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -167,6 +167,7 @@ void vimSetFormatCallback(FormatCallback formatCallback);
 void vimSetGotoCallback(GotoCallback gotoCallback);
 void vimSetTabPageCallback(TabPageCallback tabPageCallback);
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
+void vimSetOptionSetCallback(OptionSetCallback callback);
 
 /*
  * vimSetQuitCallback

--- a/src/option.c
+++ b/src/option.c
@@ -1336,6 +1336,7 @@ static struct vimoption options[] =
         {"maxmemtot", "mmt", P_NUM | P_VI_DEF, (char_u *)&p_mmt, PV_NONE, {(char_u *)DFLT_MAXMEMTOT, (char_u *)0L} SCTX_INIT},
         {"menuitems", "mis", P_NUM | P_VI_DEF, (char_u *)NULL, PV_NONE, {(char_u *)25L, (char_u *)0L} SCTX_INIT},
         {"mesg", NULL, P_BOOL | P_VI_DEF, (char_u *)NULL, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+        {"minimap", NULL, P_BOOL | P_VI_DEF, (char_u *)&p_minimap, PV_NONE, {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
         {"mkspellmem", "msm", P_STRING | P_VI_DEF | P_EXPAND | P_SECURE, (char_u *)NULL, PV_NONE, {(char_u *)0L, (char_u *)0L} SCTX_INIT},
         {"modeline", "ml", P_BOOL | P_VIM, (char_u *)&p_ml, PV_ML, {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
         {"modelineexpr", "mle", P_BOOL | P_VI_DEF | P_SECURE, (char_u *)&p_mle, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
@@ -1799,6 +1800,7 @@ static struct vimoption options[] =
 #endif
          {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
         {"smarttab", "sta", P_BOOL | P_VI_DEF | P_VIM, (char_u *)&p_sta, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+        {"smoothscroll", NULL, P_BOOL | P_VI_DEF | P_VIM, (char_u *)&p_smoothscroll, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
         {"softtabstop", "sts", P_NUM | P_VI_DEF | P_VIM, (char_u *)&p_sts, PV_STS, {(char_u *)0L, (char_u *)0L} SCTX_INIT},
         {"sourceany", NULL, P_BOOL | P_VI_DEF, (char_u *)NULL, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
         {"spell", NULL, P_BOOL | P_VI_DEF | P_RWIN, (char_u *)NULL, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
@@ -4046,6 +4048,57 @@ did_set_option(
                        // P_INSECURE flag.
 {
   long_u *p;
+
+  printf("!did_set_option - idx: %d opt_flags: %d\n", opt_idx, opt_flags);
+  char_u *fullname = options[opt_idx].fullname;
+  char_u *shortname = options[opt_idx].shortname;
+  long numval;
+  char_u *stringval;
+  printf("--1\n");
+  int optionType = get_option_value(fullname,
+                                    &numval,
+                                    &stringval,
+                                    opt_flags);
+  if (optionType == 0 || optionType == 1 || optionType == -1 || optionType == -2)
+  {
+    int hidden = optionType < 0;
+    int type = optionType;
+    if (optionType == -1)
+    {
+      type = 0;
+    }
+    else if (optionType == -2)
+    {
+      type = 1;
+    }
+
+    if (optionSetCallback != NULL)
+    {
+      optionSet_T optionSetInfo;
+      optionSetInfo.fullname = fullname;
+      optionSetInfo.shortname = shortname;
+      optionSetInfo.type = type;
+      optionSetInfo.numval = numval;
+      optionSetInfo.stringval = stringval;
+      optionSetInfo.opt_flags = opt_flags;
+      optionSetInfo.hidden = hidden;
+
+      optionSetCallback(&optionSetInfo);
+    }
+  }
+
+  printf("--2\n");
+
+  if (optionType == 1)
+  {
+    printf(" -- option -name: %s val: %ld\n", fullname, numval);
+  }
+  else
+  {
+    printf(" -- option -name: %s val: %s\n", fullname, stringval);
+  }
+
+  //printf(" -- option - name: %s value: %s\n", options[opt_idx].fullname, options[opt_idx].var);
 
   options[opt_idx].flags |= P_WAS_SET;
 

--- a/src/option.c
+++ b/src/option.c
@@ -4049,12 +4049,10 @@ did_set_option(
 {
   long_u *p;
 
-  printf("!did_set_option - idx: %d opt_flags: %d\n", opt_idx, opt_flags);
   char_u *fullname = options[opt_idx].fullname;
   char_u *shortname = options[opt_idx].shortname;
   long numval;
   char_u *stringval;
-  printf("--1\n");
   int optionType = get_option_value(fullname,
                                     &numval,
                                     &stringval,
@@ -4086,19 +4084,6 @@ did_set_option(
       optionSetCallback(&optionSetInfo);
     }
   }
-
-  printf("--2\n");
-
-  if (optionType == 1)
-  {
-    printf(" -- option -name: %s val: %ld\n", fullname, numval);
-  }
-  else
-  {
-    printf(" -- option -name: %s val: %s\n", fullname, stringval);
-  }
-
-  //printf(" -- option - name: %s value: %s\n", options[opt_idx].fullname, options[opt_idx].var);
 
   options[opt_idx].flags |= P_WAS_SET;
 

--- a/src/option.c
+++ b/src/option.c
@@ -4049,29 +4049,29 @@ did_set_option(
 {
   long_u *p;
 
-  char_u *fullname = options[opt_idx].fullname;
-  char_u *shortname = options[opt_idx].shortname;
-  long numval = -1;
-  char_u *stringval = NULL;
-  int optionType = get_option_value(fullname,
-                                    &numval,
-                                    &stringval,
-                                    opt_flags);
-  if (optionType == 0 || optionType == 1 || optionType == -1 || optionType == -2)
+  if (optionSetCallback != NULL)
   {
-    int hidden = optionType < 0;
-    int type = optionType;
-    if (optionType == -1)
+    char_u *fullname = options[opt_idx].fullname;
+    char_u *shortname = options[opt_idx].shortname;
+    long numval = -1;
+    char_u *stringval = NULL;
+    int optionType = get_option_value(fullname,
+                                      &numval,
+                                      &stringval,
+                                      opt_flags);
+    if (optionType == 0 || optionType == 1 || optionType == -1 || optionType == -2)
     {
-      type = 1;
-    }
-    else if (optionType == -2)
-    {
-      type = 0;
-    }
+      int hidden = optionType < 0;
+      int type = optionType;
+      if (optionType == -1)
+      {
+        type = 1;
+      }
+      else if (optionType == -2)
+      {
+        type = 0;
+      }
 
-    if (optionSetCallback != NULL)
-    {
       optionSet_T optionSetInfo;
       optionSetInfo.fullname = fullname;
       optionSetInfo.shortname = shortname;
@@ -4082,6 +4082,10 @@ did_set_option(
       optionSetInfo.hidden = hidden;
 
       optionSetCallback(&optionSetInfo);
+      if (stringval != NULL)
+      {
+        vim_free(stringval);
+      }
     }
   }
 

--- a/src/option.c
+++ b/src/option.c
@@ -4052,7 +4052,7 @@ did_set_option(
   char_u *fullname = options[opt_idx].fullname;
   char_u *shortname = options[opt_idx].shortname;
   long numval = -1;
-  char_u *stringval = "";
+  char_u *stringval = NULL;
   int optionType = get_option_value(fullname,
                                     &numval,
                                     &stringval,

--- a/src/option.c
+++ b/src/option.c
@@ -4051,8 +4051,8 @@ did_set_option(
 
   char_u *fullname = options[opt_idx].fullname;
   char_u *shortname = options[opt_idx].shortname;
-  long numval;
-  char_u *stringval;
+  long numval = -1;
+  char_u *stringval = "";
   int optionType = get_option_value(fullname,
                                     &numval,
                                     &stringval,
@@ -4063,11 +4063,11 @@ did_set_option(
     int type = optionType;
     if (optionType == -1)
     {
-      type = 0;
+      type = 1;
     }
     else if (optionType == -2)
     {
-      type = 1;
+      type = 0;
     }
 
     if (optionSetCallback != NULL)

--- a/src/option.h
+++ b/src/option.h
@@ -512,6 +512,7 @@ EXTERN long p_mmd;       /* 'maxmapdepth' */
 EXTERN long p_mm;        /* 'maxmem' */
 EXTERN long p_mmp;       /* 'maxmempattern' */
 EXTERN long p_mmt;       /* 'maxmemtot' */
+EXTERN int p_minimap;    /* 'minimap' */
 EXTERN long p_mle;       /* 'modelineexpr' */
 EXTERN long p_mls;       /* 'modelines' */
 EXTERN char_u *p_mouse;  /* 'mouse' */
@@ -640,15 +641,16 @@ EXTERN char_u *p_shm; /* 'shortmess' */
 #ifdef FEAT_LINEBREAK
 EXTERN char_u *p_sbr; /* 'showbreak' */
 #endif
-EXTERN int p_sft;   /* 'showfulltag' */
-EXTERN int p_sm;    /* 'showmatch' */
-EXTERN int p_smd;   /* 'showmode' */
-EXTERN long p_ss;   /* 'sidescroll' */
-EXTERN long p_siso; /* 'sidescrolloff' */
-EXTERN int p_scs;   /* 'smartcase' */
-EXTERN int p_sta;   /* 'smarttab' */
-EXTERN int p_sb;    /* 'splitbelow' */
-EXTERN long p_tpm;  /* 'tabpagemax' */
+EXTERN int p_sft;          /* 'showfulltag' */
+EXTERN int p_sm;           /* 'showmatch' */
+EXTERN int p_smd;          /* 'showmode' */
+EXTERN long p_ss;          /* 'sidescroll' */
+EXTERN long p_siso;        /* 'sidescrolloff' */
+EXTERN int p_scs;          /* 'smartcase' */
+EXTERN int p_sta;          /* 'smarttab' */
+EXTERN int p_smoothscroll; /* 'smoothscroll' */
+EXTERN int p_sb;           /* 'splitbelow' */
+EXTERN long p_tpm;         /* 'tabpagemax' */
 #if defined(FEAT_STL_OPT)
 EXTERN char_u *p_tal; /* 'tabline' */
 #endif

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libvim",
-  "version": "8.10869.55",
+  "version": "8.10869.56",
   "description": "Standalone vim library",
   "license": "MIT",
   "scripts": {

--- a/src/structs.h
+++ b/src/structs.h
@@ -2430,11 +2430,28 @@ typedef enum
   FILE_CHANGED,
 } writeFailureReason_T;
 
+typedef struct
+{
+  char_u *fullname;
+  char_u *shortname;
+
+  // Type can be:
+  // Number or toggle: 1 -> value is in numval
+  // String: 0 -> value is in stringval
+  int type;
+
+  long numval;
+  char_u *stringval;
+  int opt_flags; // [ OPT_FREE | OPT_LOCAL | OPT_GLOBAL ]
+  int hidden;
+} optionSet_T;
+
 typedef void (*BufferUpdateCallback)(bufferUpdate_T bufferUpdate);
 typedef void (*FileWriteFailureCallback)(writeFailureReason_T failureReason, buf_T *buf);
 typedef void (*MessageCallback)(char_u *title, char_u *msg, msgPriority_T priority);
 typedef void (*DirectoryChangedCallback)(char_u *path);
 typedef void (*QuitCallback)(buf_T *buf, int isForced);
+typedef void (*OptionSetCallback)(optionSet_T *optionSet);
 
 #ifdef FEAT_DIFF
 /*


### PR DESCRIPTION
This adds a callback whenever an option is set (ie `:set rnu`) - this will give us a hook to synchronize more vim settings and options in Onivim.

Also experiments with adding a couple of options:
- `set minimap`/`set nominimap` - turn on / off minimap
- `set smoothscroll` / `set nosmoothscroll` - turn on / off smooth scroll