### PR TITLE
vimBufferSetLines: update documentation

### DIFF
--- a/src/libvim.h
+++ b/src/libvim.h
@@ -51,9 +51,9 @@ size_t vimBufferGetLineCount(buf_T *buf);
  * splice in new lines in-between existing lines. 
  *
  * Examples:
+ * vimBufferSetLines(buf, 0, 0, ["abc"], 1); // Insert "abc" above the current first line, pushing down all existing lines
  * vimBufferSetLines(buf, 0, 1, ["abc"], 1); // Set line 1 to "abc"
  * vimBufferSetLines(buf, 0, 2, ["abc"], 2); // Set line 1 to "abc", make line 2 empty
- * vimBufferSetLines(buf, 0, 0, ["abc"], 1); // Insert "abc" above the current fist line, pushing down all existing lines
  * vimBufferSetLines(buf, 2, 2, ["abc"], 1); // Splice "abc" after the second line, pushing the existing lines from 3 on down
  *
  */

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -46,12 +46,16 @@ size_t vimBufferGetLineCount(buf_T *buf);
 /*
  * vimBufferSetLines
  *
- * Set a range of lines from the one-based start line to one-based end, inclusive.
- * 
+ * Set a range of lines into the buffer. The start parameter is zero based and inclusive.
+ * The end parameter is exclusive. This means you can either replace existing lines, or
+ * splice in new lines in-between existing lines. 
+ *
  * Examples:
- * vimBufferSetLine(buf, 1, 1, ["abc"]); // Set line 1 to "abc""
- * vimBufferSetLine(buf, 1, 2, ["abc"]); // Remove line 2, set line 1 to "abc"
- * vimBufferSetLine(buf, 0, 0, ["def"]); // Insert "def" before the contents of the buffer
+ * vimBufferSetLines(buf, 0, 1, ["abc"], 1); // Set line 1 to "abc"
+ * vimBufferSetLines(buf, 0, 2, ["abc"], 2); // Set line 1 to "abc", make line 2 empty
+ * vimBufferSetLines(buf, 0, 0, ["abc"], 1); // Insert "abc" above the current fist line, pushing down all existing lines
+ * vimBufferSetLines(buf, 2, 2, ["abc"], 1); // Splice "abc" after the second line, pushing the existing lines from 3 on down
+ *
  */
 void vimBufferSetLines(buf_T *buf, linenr_T start, linenr_T end, char_u **lines, int count);
 
@@ -73,7 +77,6 @@ void vimSetBufferUpdateCallback(BufferUpdateCallback bufferUpdate);
  ***/
 
 void vimSetAutoCommandCallback(AutoCommandCallback autoCommandDispatch);
-
 /**
  * Commandline
  ***/


### PR DESCRIPTION
This PR is not intended for merging, at least not yet.

I am unsure if this is a bug or if I am misusing the API.

The added test fails with:

```
-- START set_lines_into_empty_buffer --
LINE 0: 
LINE 1: 
LINE 2: line 1
LINE 3: line 2
LINE 4: line 3
LINE 5: line 4
[FAILED]
set_lines_into_empty_buffer failed:
	apitest/buffer_set_lines.c:175: strcmp(vimBufferGetLine(buf, 1), "line1") == 0

-- END set_lines_into_empty_buffer -
```

I am attempting to place a block of lines into an empty buffer in one pass. But when I do that, the lines I get back from vim are not what I expect. In the test they appear to be off by two blank lines, but in my app the lines I got back were all kinds of strange things.

Here is where I am using vimBufferSetLines in my app: https://github.com/city41/Godot_VimTextEdit/blob/master/vim/text_edit.cpp#L4860

I originally was doing this

```
int len = text.size();
char** rawLines = new char*[len];

for (int i = 0; i < len; i++) {
        // returns a null terminated char*, ie a c string
        rawLines[i] = text[i].ascii().get_data();
}

vimBufferSetLines(vimBuf, 1, len, rawLines, len);
```

I changed it to this, which fixed the issue for me:

```
	int len = text.size();
	char* rawLines[1];

	for (int i = len - 1; i >= 0; i--) {
		rawLines[0] = text[i].ascii().get_data();
		vimBufferSetLines(vimBuf, 0, 0, rawLines, 1);
	}
```

I am inserting the lines from bottom to top, one at a time. This appears to also be what `vimBufferSetLines` itself does when it is sent a batch of lines.