### PR TITLE
feat(api): Add vimBufferLoad API

### DIFF
--- a/src/apitest/buflist.c
+++ b/src/apitest/buflist.c
@@ -19,7 +19,7 @@ MU_TEST(buflist_get_id)
   mu_check(vimBufferGetById(currentId) == current);
 }
 
-MU_TEST(buffer_load)
+MU_TEST(buffer_open)
 {
   buf_T *buf = vimBufferOpen("collateral/curswant.txt", 1, 0);
   long lines = vimBufferGetLineCount(buf);
@@ -27,12 +27,45 @@ MU_TEST(buffer_load)
   mu_check(lines == 4);
 }
 
+MU_TEST(buffer_load_nonexistent_file)
+{
+  buf_T *buf = vimBufferLoad("a-non-existent-file.txt", 1, 0);
+  long lines = vimBufferGetLineCount(buf);
+  mu_check(lines == 1);
+}
+
+MU_TEST(buffer_load_does_not_change_current)
+{
+  buf_T *bufOpen = vimBufferOpen("collateral/curswant.txt", 1, 0);
+  buf_T *bufLoaded = vimBufferLoad("a-non-existent-file.txt", 1, 0);
+  long loadedLines = vimBufferGetLineCount(bufLoaded);
+  mu_check(loadedLines == 1);
+
+  long openLines = vimBufferGetLineCount(bufOpen);
+  mu_check(openLines == 4);
+
+  buf_T *currentBuf = vimBufferGetCurrent();
+
+  mu_check(currentBuf == bufOpen);
+}
+
+MU_TEST(buffer_load_read_lines)
+{
+  buf_T *bufLoaded = vimBufferLoad("collateral/testfile.txt", 1, 0);
+  mu_check(strcmp(vimBufferGetLine(bufLoaded, 1), "This is the first line of a test file") == 0);
+  mu_check(strcmp(vimBufferGetLine(bufLoaded, 2), "This is the second line of a test file") == 0);
+  mu_check(strcmp(vimBufferGetLine(bufLoaded, 3), "This is the third line of a test file") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(buflist_get_id);
-  MU_RUN_TEST(buffer_load);
+  MU_RUN_TEST(buffer_open);
+  MU_RUN_TEST(buffer_load_nonexistent_file);
+  MU_RUN_TEST(buffer_load_does_not_change_current);
+  MU_RUN_TEST(buffer_load_read_lines);
 }
 
 int main(int argc, char **argv)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -11,9 +11,15 @@
 
 #include "vim.h"
 
-buf_T *vimBufferOpen(char_u *ffname_arg, linenr_T lnum, int flags)
+buf_T *vimBufferLoad(char_u *ffname_arg, linenr_T lnum, int flags)
 {
   buf_T *buffer = buflist_new(ffname_arg, NULL, lnum, flags);
+  return buffer;
+}
+
+buf_T *vimBufferOpen(char_u *ffname_arg, linenr_T lnum, int flags)
+{
+  buf_T *buffer = vimBufferLoad(ffname_arg, lnum, flags);
   set_curbuf(buffer, DOBUF_SPLIT);
   return buffer;
 }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -23,6 +23,15 @@ void vimInit(int argc, char **argv);
  */
 
 buf_T *vimBufferOpen(char_u *ffname_arg, linenr_T lnum, int flags);
+
+/*
+ * vimBufferOpen
+ *
+ * Load a buffer, but do not change current buffer.
+ */
+
+buf_T *vimBufferLoad(char_u *ffname_arg, linenr_T lnum, int flags);
+
 /*
  * vimBufferCheckIfChanged
  *


### PR DESCRIPTION
This adds a `vimBufferLoad` API, which loads a buffer without the side-effect of setting it as current.