### PR TITLE
feat(api): Callbacks for screen-wise cursor motion

### DIFF
--- a/src/apitest/motion_screen.c
+++ b/src/apitest/motion_screen.c
@@ -3,6 +3,9 @@
 
 void test_setup(void)
 {
+  vimKey("<Esc>");
+  vimKey("<Esc>");
+  vimExecute("e!");
   vimInput("g");
   vimInput("g");
   vimInput("0");
@@ -10,7 +13,7 @@ void test_setup(void)
 
 void test_teardown(void) {}
 
-void SimpleCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
+void SimpleScreenLineCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
 {
   switch (motion)
   {
@@ -26,7 +29,7 @@ void SimpleCallback(screenLineMotion_T motion, int count, linenr_T startLine, li
   }
 }
 
-void ErroneousCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
+void ErroneousScreenLineCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
 {
   switch (motion)
   {
@@ -39,6 +42,34 @@ void ErroneousCallback(screenLineMotion_T motion, int count, linenr_T startLine,
   case MOTION_L:
     *outLine = 999;
     break;
+  }
+}
+
+void SimplePositionCallback(int dir, int count, linenr_T srcLine, colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn)
+{
+  if (dir == BACKWARD)
+  {
+    *destLine = 1;
+    *destColumn = 0;
+  }
+  else
+  {
+    *destLine = 100;
+    *destColumn = 0;
+  }
+}
+
+void SameLinePositionCallback(int dir, int count, linenr_T srcLine, colnr_T srcColumn, linenr_T *destLine, colnr_T *destColumn)
+{
+  if (dir == BACKWARD)
+  {
+    *destLine = srcLine;
+    *destColumn = 0;
+  }
+  else
+  {
+    *destLine = srcLine;
+    *destColumn = srcColumn + 1;
   }
 }
 
@@ -83,7 +114,7 @@ MU_TEST(test_no_callback)
 MU_TEST(test_simple_callback)
 {
   // When no callback is set, the cursor should not move at all.
-  vimSetCursorMoveScreenLineCallback(&SimpleCallback);
+  vimSetCursorMoveScreenLineCallback(&SimpleScreenLineCallback);
 
   vimInput("H");
 
@@ -104,7 +135,7 @@ MU_TEST(test_simple_callback)
 MU_TEST(test_erroneous_callback)
 {
   // When no callback is set, the cursor should not move at all.
-  vimSetCursorMoveScreenLineCallback(&ErroneousCallback);
+  vimSetCursorMoveScreenLineCallback(&ErroneousScreenLineCallback);
 
   vimInput("H");
 
@@ -112,7 +143,6 @@ MU_TEST(test_erroneous_callback)
   mu_check(vimCursorGetColumn() == 0);
 
   vimInput("L");
-  printf("LINE: %ld\n", vimCursorGetLine());
 
   mu_check(vimCursorGetLine() == 100);
   mu_check(vimCursorGetColumn() == 0);
@@ -123,6 +153,58 @@ MU_TEST(test_erroneous_callback)
   mu_check(vimCursorGetColumn() == 0);
 }
 
+MU_TEST(test_gj_gk_motion)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenPositionCallback(&SimplePositionCallback);
+
+  vimInput("gj");
+
+  printf("LINE: %ld\n", vimCursorGetLine());
+  mu_check(vimCursorGetLine() == 100);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("gk");
+  printf("LINE: %ld\n", vimCursorGetLine());
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
+MU_TEST(test_gk_motion_same_line)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenPositionCallback(&SameLinePositionCallback);
+
+  vimInput("3l");
+  vimInput("d");
+  vimInput("gk");
+
+  printf("LINE: %ld\n", vimCursorGetLine());
+  printf("CONTENTS: %s\n", vimBufferGetLine(curbuf, 1));
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "e 1") == 0);
+}
+
+MU_TEST(test_gj_motion_same_line)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenPositionCallback(&SameLinePositionCallback);
+
+  vimInput("3l");
+  vimInput("d");
+  vimInput("gj");
+
+  printf("LINE: %ld\n", vimCursorGetLine());
+  printf("CONTENTS: %s\n", vimBufferGetLine(curbuf, 1));
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 2);
+  mu_check(strcmp(vimBufferGetLine(curbuf, 1), "Lin 1") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -130,6 +212,9 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_no_callback);
   MU_RUN_TEST(test_simple_callback);
   MU_RUN_TEST(test_erroneous_callback);
+  MU_RUN_TEST(test_gj_gk_motion);
+  MU_RUN_TEST(test_gk_motion_same_line);
+  MU_RUN_TEST(test_gj_motion_same_line);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/motion_screen.c
+++ b/src/apitest/motion_screen.c
@@ -1,0 +1,147 @@
+#include "libvim.h"
+#include "minunit.h"
+
+void test_setup(void)
+{
+  vimInput("g");
+  vimInput("g");
+  vimInput("0");
+}
+
+void test_teardown(void) {}
+
+void SimpleCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
+{
+  switch (motion)
+  {
+  case MOTION_H:
+    *outLine = 10;
+    break;
+  case MOTION_M:
+    *outLine = 20;
+    break;
+  case MOTION_L:
+    *outLine = 30;
+    break;
+  }
+}
+
+void ErroneousCallback(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *outLine)
+{
+  switch (motion)
+  {
+  case MOTION_H:
+    *outLine = -1;
+    break;
+  case MOTION_M:
+    *outLine = 101;
+    break;
+  case MOTION_L:
+    *outLine = 999;
+    break;
+  }
+}
+
+MU_TEST(test_no_callback)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenLineCallback(NULL);
+
+  vimInput("H");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("L");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("M");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("j");
+
+  vimInput("H");
+
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("L");
+
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("M");
+
+  mu_check(vimCursorGetLine() == 2);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
+MU_TEST(test_simple_callback)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenLineCallback(&SimpleCallback);
+
+  vimInput("H");
+
+  mu_check(vimCursorGetLine() == 10);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("L");
+
+  mu_check(vimCursorGetLine() == 30);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("M");
+
+  mu_check(vimCursorGetLine() == 20);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
+MU_TEST(test_erroneous_callback)
+{
+  // When no callback is set, the cursor should not move at all.
+  vimSetCursorMoveScreenLineCallback(&ErroneousCallback);
+
+  vimInput("H");
+
+  mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("L");
+  printf("LINE: %ld\n", vimCursorGetLine());
+
+  mu_check(vimCursorGetLine() == 100);
+  mu_check(vimCursorGetColumn() == 0);
+
+  vimInput("M");
+
+  mu_check(vimCursorGetLine() == 100);
+  mu_check(vimCursorGetColumn() == 0);
+}
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
+
+  MU_RUN_TEST(test_no_callback);
+  MU_RUN_TEST(test_simple_callback);
+  MU_RUN_TEST(test_erroneous_callback);
+}
+
+int main(int argc, char **argv)
+{
+  vimInit(argc, argv);
+
+  win_setwidth(5);
+  win_setheight(100);
+
+  vimBufferOpen("collateral/lines_100.txt", 1, 0);
+
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  MU_RETURN();
+}

--- a/src/apitest/normal_mode_curswant.c
+++ b/src/apitest/normal_mode_curswant.c
@@ -68,6 +68,7 @@ MU_TEST(test_curswant_reset)
 
   mu_check(vimCursorGetColumn() == 1);
   mu_check(vimCursorGetLine() == 1);
+  mu_check(vimCursorGetColumnWant() == 1);
 
   // Move three characters down
   vimInput("j");
@@ -78,6 +79,21 @@ MU_TEST(test_curswant_reset)
   mu_check(vimCursorGetLine() == 4);
 }
 
+MU_TEST(test_setting_curswant_explicitly)
+{
+  mu_check(vimCursorGetLine() == 1);
+
+  vimCursorSetColumnWant(MAXCOL);
+
+  // Move three characters down
+  vimInput("j");
+  vimInput("j");
+  vimInput("j");
+
+  mu_check(vimCursorGetColumn() == 3);
+  mu_check(vimCursorGetLine() == 4);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -85,6 +101,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_curswant_column2);
   MU_RUN_TEST(test_curswant_maxcolumn);
   MU_RUN_TEST(test_curswant_reset);
+  MU_RUN_TEST(test_setting_curswant_explicitly);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/scroll.c
+++ b/src/apitest/scroll.c
@@ -84,26 +84,6 @@ MU_TEST(test_small_screen_scroll)
   mu_check(vimCursorGetLine() == 50);
 }
 
-MU_TEST(test_h_m_l)
-{
-  vimWindowSetWidth(80);
-  vimWindowSetHeight(40);
-
-  mu_check(vimCursorGetLine() == 50);
-
-  vimInput("z");
-  vimInput("z");
-
-  vimInput("H");
-  mu_check(vimCursorGetLine() == 31);
-
-  vimInput("L");
-  mu_check(vimCursorGetLine() == 70);
-
-  vimInput("M");
-  mu_check(vimCursorGetLine() == 50);
-}
-
 MU_TEST(test_only_scroll_at_boundary)
 {
 
@@ -255,7 +235,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_set_get_metrics);
   MU_RUN_TEST(test_simple_scroll);
   MU_RUN_TEST(test_small_screen_scroll);
-  MU_RUN_TEST(test_h_m_l);
   MU_RUN_TEST(test_only_scroll_at_boundary);
   MU_RUN_TEST(test_no_scroll_after_setting_topline);
   MU_RUN_TEST(test_scroll_left_at_boundary);

--- a/src/globals.h
+++ b/src/globals.h
@@ -58,6 +58,7 @@ EXTERN VoidCallback displayVersionCallback INIT(= NULL);
 EXTERN AutoIndentCallback autoIndentCallback INIT(= NULL);
 EXTERN ColorSchemeChangedCallback colorSchemeChangedCallback INIT(= NULL);
 EXTERN ColorSchemeCompletionCallback colorSchemeCompletionCallback INIT(= NULL);
+EXTERN CursorMoveScreenLineCallback cursorMoveScreenLineCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
 EXTERN MacroStartRecordCallback macroStartRecordCallback INIT(= NULL);
 EXTERN MacroStopRecordCallback macroStopRecordCallback INIT(= NULL);

--- a/src/globals.h
+++ b/src/globals.h
@@ -59,6 +59,7 @@ EXTERN AutoIndentCallback autoIndentCallback INIT(= NULL);
 EXTERN ColorSchemeChangedCallback colorSchemeChangedCallback INIT(= NULL);
 EXTERN ColorSchemeCompletionCallback colorSchemeCompletionCallback INIT(= NULL);
 EXTERN CursorMoveScreenLineCallback cursorMoveScreenLineCallback INIT(= NULL);
+EXTERN CursorMoveScreenPositionCallback cursorMoveScreenPositionCallback INIT(= NULL);
 EXTERN MessageCallback messageCallback INIT(= NULL);
 EXTERN MacroStartRecordCallback macroStartRecordCallback INIT(= NULL);
 EXTERN MacroStopRecordCallback macroStopRecordCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -229,6 +229,16 @@ void vimCursorSetPosition(pos_T pos)
   curs_columns(TRUE);
 }
 
+void vimCursorSetColumnWant(colnr_T curswant)
+{
+  curwin->w_curswant = curswant;
+}
+
+colnr_T vimCursorGetColumnWant(void)
+{
+  return curwin->w_curswant;
+}
+
 void vimInputCore(int should_replace_termcodes, char_u *input)
 {
   if (should_replace_termcodes)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -134,6 +134,12 @@ void vimSetCursorMoveScreenLineCallback(
   cursorMoveScreenLineCallback = f;
 }
 
+void vimSetCursorMoveScreenPositionCallback(
+    CursorMoveScreenPositionCallback f)
+{
+  cursorMoveScreenPositionCallback = f;
+}
+
 void vimSetFileWriteFailureCallback(FileWriteFailureCallback f)
 {
   fileWriteFailureCallback = f;

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -128,6 +128,12 @@ void vimSetAutoCommandCallback(AutoCommandCallback f)
   autoCommandCallback = f;
 }
 
+void vimSetCursorMoveScreenLineCallback(
+    CursorMoveScreenLineCallback f)
+{
+  cursorMoveScreenLineCallback = f;
+}
+
 void vimSetFileWriteFailureCallback(FileWriteFailureCallback f)
 {
   fileWriteFailureCallback = f;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -111,6 +111,8 @@ char_u *vimEval(char_u *str);
  * Cursor Methods
  ***/
 colnr_T vimCursorGetColumn(void);
+colnr_T vimCursorGetColumnWant(void);
+void vimCursorSetColumnWant(colnr_T curswant);
 linenr_T vimCursorGetLine(void);
 pos_T vimCursorGetPosition(void);
 void vimCursorSetPosition(pos_T pos);

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -134,6 +134,16 @@ void vimSetCursorMoveScreenLineCallback(
     CursorMoveScreenLineCallback cursorMoveScreenLineCallback);
 
 /***
+ * vimSetCursorMoveScreenLineCallback
+ *
+ * Callback when the cursor will be moved via screen position (gj, gk).
+ * Because the libvim-consumer is responsible for managing the view,
+ * libvim needs information about the view to correctly handle these motions.
+ */
+void vimSetCursorMoveScreenPositionCallback(
+    CursorMoveScreenPositionCallback cursorMoveScreenPositionCallback);
+
+/***
  * File I/O
  ***/
 void vimSetFileWriteFailureCallback(FileWriteFailureCallback fileWriteFailureCallback);

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -124,6 +124,16 @@ void vimCursorSetPosition(pos_T pos);
 colnr_T vimCursorGetDesiredColumn(void);
 
 /***
+ * vimSetCursorMoveScreenLineCallback
+ *
+ * Callback when the cursor will be moved via screen lines (H, M, L).
+ * Because the libvim-consumer is responsible for managing the view,
+ * libvim needs information about the view to correctly handle these motions.
+ */
+void vimSetCursorMoveScreenLineCallback(
+    CursorMoveScreenLineCallback cursorMoveScreenLineCallback);
+
+/***
  * File I/O
  ***/
 void vimSetFileWriteFailureCallback(FileWriteFailureCallback fileWriteFailureCallback);

--- a/src/normal.c
+++ b/src/normal.c
@@ -3374,144 +3374,30 @@ int find_decl(char_u *ptr, int len, int locally, int thisblock,
  */
 static int nv_screengo(oparg_T *oap, int dir, long dist)
 {
-  int linelen = linetabsize(ml_get_curline());
   int retval = OK;
-  int atend = FALSE;
-  int n;
-  int col_off1; /* margin offset for first screen line */
-  int col_off2; /* margin offset for wrapped screen line */
-  int width1;   /* text width for first screen line */
-  int width2;   /* test width for wrapped screen line */
 
   oap->motion_type = MCHAR;
   oap->inclusive = (curwin->w_curswant == MAXCOL);
 
-  col_off1 = curwin_col_off();
-  col_off2 = col_off1 - curwin_col_off2();
-  width1 = curwin->w_width - col_off1;
-  width2 = curwin->w_width - col_off2;
-  if (width2 == 0)
-    width2 = 1; /* avoid divide by zero */
+  linenr_T destinationLnum = curwin->w_cursor.lnum;
+  colnr_T destColumn = curwin->w_curswant;
 
-  if (curwin->w_width != 0)
+  if (cursorMoveScreenPositionCallback != NULL)
   {
-    /*
-     * Instead of sticking at the last character of the buffer line we
-     * try to stick in the last column of the screen.
-     */
-    if (curwin->w_curswant == MAXCOL)
-    {
-      atend = TRUE;
-      validate_virtcol();
-      if (width1 <= 0)
-        curwin->w_curswant = 0;
-      else
-      {
-        curwin->w_curswant = width1 - 1;
-        if (curwin->w_virtcol > curwin->w_curswant)
-          curwin->w_curswant +=
-              ((curwin->w_virtcol - curwin->w_curswant - 1) / width2 + 1) *
-              width2;
-      }
-    }
-    else
-    {
-      if (linelen > width1)
-        n = ((linelen - width1 - 1) / width2 + 1) * width2 + width1;
-      else
-        n = width1;
-      if (curwin->w_curswant > (colnr_T)n + 1)
-        curwin->w_curswant -= ((curwin->w_curswant - n) / width2 + 1) * width2;
-    }
-
-    while (dist--)
-    {
-      if (dir == BACKWARD)
-      {
-        if ((long)curwin->w_curswant >= width2)
-          /* move back within line */
-          curwin->w_curswant -= width2;
-        else
-        {
-          /* to previous line */
-          if (curwin->w_cursor.lnum == 1)
-          {
-            retval = FAIL;
-            break;
-          }
-          --curwin->w_cursor.lnum;
-#ifdef FEAT_FOLDING
-          /* Move to the start of a closed fold.  Don't do that when
-           * 'foldopen' contains "all": it will open in a moment. */
-          if (!(fdo_flags & FDO_ALL))
-            (void)hasFolding(curwin->w_cursor.lnum, &curwin->w_cursor.lnum,
-                             NULL);
-#endif
-          linelen = linetabsize(ml_get_curline());
-          if (linelen > width1)
-            curwin->w_curswant +=
-                (((linelen - width1 - 1) / width2) + 1) * width2;
-        }
-      }
-      else /* dir == FORWARD */
-      {
-        if (linelen > width1)
-          n = ((linelen - width1 - 1) / width2 + 1) * width2 + width1;
-        else
-          n = width1;
-        if (curwin->w_curswant + width2 < (colnr_T)n)
-          /* move forward within line */
-          curwin->w_curswant += width2;
-        else
-        {
-          /* to next line */
-#ifdef FEAT_FOLDING
-          /* Move to the end of a closed fold. */
-          (void)hasFolding(curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum);
-#endif
-          if (curwin->w_cursor.lnum == curbuf->b_ml.ml_line_count)
-          {
-            retval = FAIL;
-            break;
-          }
-          curwin->w_cursor.lnum++;
-          curwin->w_curswant %= width2;
-          linelen = linetabsize(ml_get_curline());
-        }
-      }
-    }
+    cursorMoveScreenPositionCallback(
+        dir,
+        dist,
+        curwin->w_cursor.lnum,
+        curwin->w_cursor.col,
+        &destinationLnum,
+        &destColumn);
+    curwin->w_cursor.lnum = destinationLnum;
+    curwin->w_cursor.col = destColumn;
   }
-
-  if (virtual_active() && atend)
-    coladvance(MAXCOL);
   else
-    coladvance(curwin->w_curswant);
-
-  if (curwin->w_cursor.col > 0 && curwin->w_p_wrap)
   {
-    colnr_T virtcol;
-
-    /*
-     * Check for landing on a character that got split at the end of the
-     * last line.  We want to advance a screenline, not end up in the same
-     * screenline or move two screenlines.
-     */
-    validate_virtcol();
-    virtcol = curwin->w_virtcol;
-#if defined(FEAT_LINEBREAK)
-    if (virtcol > (colnr_T)width1 && *p_sbr != NUL)
-      virtcol -= vim_strsize(p_sbr);
-#endif
-
-    if (virtcol > curwin->w_curswant &&
-        (curwin->w_curswant < (colnr_T)width1
-             ? (curwin->w_curswant > (colnr_T)width1 / 2)
-             : ((curwin->w_curswant - width1) % width2 > (colnr_T)width2 / 2)))
-      --curwin->w_cursor.col;
+    retval = FAIL;
   }
-
-  if (atend)
-    curwin->w_curswant = MAXCOL; /* stick in the last column */
 
   return retval;
 }
@@ -6357,38 +6243,14 @@ static void nv_g_cmd(cmdarg_T *cap)
    */
   case 'j':
   case K_DOWN:
-    /* with 'nowrap' it works just like the normal "j" command; also when
-     * in a closed fold */
-    if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-        || hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-    )
-    {
-      oap->motion_type = MLINE;
-      i = cursor_down(cap->count1, oap->op_type == OP_NOP);
-    }
-    else
-      i = nv_screengo(oap, FORWARD, cap->count1);
+    i = nv_screengo(oap, FORWARD, cap->count1);
     if (i == FAIL)
       clearopbeep(oap);
     break;
 
   case 'k':
   case K_UP:
-    /* with 'nowrap' it works just like the normal "k" command; also when
-     * in a closed fold */
-    if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-        || hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-    )
-    {
-      oap->motion_type = MLINE;
-      i = cursor_up(cap->count1, oap->op_type == OP_NOP);
-    }
-    else
-      i = nv_screengo(oap, BACKWARD, cap->count1);
+    i = nv_screengo(oap, BACKWARD, cap->count1);
     if (i == FAIL)
       clearopbeep(oap);
     break;

--- a/src/normal.c
+++ b/src/normal.c
@@ -3392,7 +3392,7 @@ static int nv_screengo(oparg_T *oap, int dir, long dist)
         &destinationLnum,
         &destColumn);
     curwin->w_cursor.lnum = destinationLnum;
-    curwin->w_cursor.col = destColumn;
+    coladvance(destColumn);
   }
   else
   {

--- a/src/normal.c
+++ b/src/normal.c
@@ -4488,98 +4488,65 @@ static void nv_tagpop(cmdarg_T *cap)
  */
 static void nv_scroll(cmdarg_T *cap)
 {
-  int used = 0;
-  long n;
-#ifdef FEAT_FOLDING
-  linenr_T lnum;
-#endif
-  int half;
+  //  int used = 0;
+  //  long n;
+  //  int half;
 
   cap->oap->motion_type = MLINE;
   setpcmark();
+  linenr_T destinationCursor = curwin->w_cursor.lnum;
 
   if (cap->cmdchar == 'L')
   {
-    validate_botline(); /* make sure curwin->w_botline is valid */
-    curwin->w_cursor.lnum = curwin->w_botline - 1;
-    if (cap->count1 - 1 >= curwin->w_cursor.lnum)
-      curwin->w_cursor.lnum = 1;
-    else
+    if (cursorMoveScreenLineCallback != NULL)
     {
-#ifdef FEAT_FOLDING
-      if (hasAnyFolding(curwin))
-      {
-        /* Count a fold for one screen line. */
-        for (n = cap->count1 - 1;
-             n > 0 && curwin->w_cursor.lnum > curwin->w_topline; --n)
-        {
-          (void)hasFolding(curwin->w_cursor.lnum, &curwin->w_cursor.lnum, NULL);
-          --curwin->w_cursor.lnum;
-        }
-      }
-      else
-#endif
-        curwin->w_cursor.lnum -= cap->count1 - 1;
+      cursorMoveScreenLineCallback(
+          MOTION_L,
+          cap->count1,
+          curwin->w_cursor.lnum,
+          &destinationCursor);
     }
   }
   else
   {
     if (cap->cmdchar == 'M')
     {
-#ifdef FEAT_DIFF
-      /* Don't count filler lines above the window. */
-      used -= diff_check_fill(curwin, curwin->w_topline) - curwin->w_topfill;
-#endif
-      validate_botline(); /* make sure w_empty_rows is valid */
-      half = (curwin->w_height - curwin->w_empty_rows + 1) / 2;
-      for (n = 0; curwin->w_topline + n < curbuf->b_ml.ml_line_count; ++n)
+      if (cursorMoveScreenLineCallback != NULL)
       {
-#ifdef FEAT_DIFF
-        /* Count half he number of filler lines to be "below this
-         * line" and half to be "above the next line". */
-        if (n > 0 &&
-            used + diff_check_fill(curwin, curwin->w_topline + n) / 2 >= half)
-        {
-          --n;
-          break;
-        }
-#endif
-        used += plines(curwin->w_topline + n);
-        if (used >= half)
-          break;
-#ifdef FEAT_FOLDING
-        if (hasFolding(curwin->w_topline + n, NULL, &lnum))
-          n = lnum - curwin->w_topline;
-#endif
+        cursorMoveScreenLineCallback(
+            MOTION_M,
+            cap->count1,
+            curwin->w_cursor.lnum,
+            &destinationCursor);
       }
-      if (n > 0 && used > curwin->w_height)
-        --n;
     }
     else /* (cap->cmdchar == 'H') */
     {
-      n = cap->count1 - 1;
-#ifdef FEAT_FOLDING
-      if (hasAnyFolding(curwin))
+      if (cursorMoveScreenLineCallback != NULL)
       {
-        /* Count a fold for one screen line. */
-        lnum = curwin->w_topline;
-        while (n-- > 0 && lnum < curwin->w_botline - 1)
-        {
-          (void)hasFolding(lnum, NULL, &lnum);
-          ++lnum;
-        }
-        n = lnum - curwin->w_topline;
+        cursorMoveScreenLineCallback(
+            MOTION_H,
+            cap->count1,
+            curwin->w_cursor.lnum,
+            &destinationCursor);
       }
-#endif
     }
-    curwin->w_cursor.lnum = curwin->w_topline + n;
-    if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count)
-      curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
   }
 
+  if (destinationCursor < 1)
+  {
+    destinationCursor = 1;
+  }
+  else if (destinationCursor > curbuf->b_ml.ml_line_count)
+  {
+    destinationCursor = curbuf->b_ml.ml_line_count;
+  }
+
+  curwin->w_cursor.lnum = destinationCursor;
   /* Correct for 'so', except when an operator is pending. */
-  if (cap->oap->op_type == OP_NOP)
-    cursor_correct();
+  // LIBVIM: Todo - where should this be handled?
+  //  if (cap->oap->op_type == OP_NOP)
+  //    cursor_correct();
   beginline(BL_SOL | BL_FIX);
 }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -3375,9 +3375,15 @@ int find_decl(char_u *ptr, int len, int locally, int thisblock,
 static int nv_screengo(oparg_T *oap, int dir, long dist)
 {
   int retval = OK;
+  int atend = FALSE;
 
   oap->motion_type = MCHAR;
   oap->inclusive = (curwin->w_curswant == MAXCOL);
+
+  if (curwin->w_curswant == MAXCOL)
+  {
+    atend = TRUE;
+  }
 
   linenr_T destinationLnum = curwin->w_cursor.lnum;
   colnr_T destColumn = curwin->w_curswant;
@@ -3389,10 +3395,17 @@ static int nv_screengo(oparg_T *oap, int dir, long dist)
         dist,
         curwin->w_cursor.lnum,
         curwin->w_cursor.col,
+        curwin->w_curswant,
         &destinationLnum,
         &destColumn);
     curwin->w_cursor.lnum = destinationLnum;
-    coladvance(destColumn);
+    curwin->w_curswant = destColumn;
+    coladvance(curwin->w_curswant);
+
+    if (atend)
+    {
+      curwin->w_curswant = MAXCOL;
+    }
   }
   else
   {

--- a/src/structs.h
+++ b/src/structs.h
@@ -160,6 +160,10 @@ typedef enum
 } screenLineMotion_T;
 typedef void (*CursorMoveScreenLineCallback)(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *destLine);
 
+typedef void (*CursorMoveScreenPositionCallback)(
+    int direction, int count, linenr_T lnum, colnr_T cursor,
+    linenr_T *destLnum, colnr_T *destCol);
+
 typedef struct
 {
   sds contents;

--- a/src/structs.h
+++ b/src/structs.h
@@ -152,6 +152,14 @@ typedef void (*TerminalCallback)(terminalRequest_t *terminalRequest);
 typedef int (*GotoCallback)(gotoRequest_T gotoInfo);
 typedef int (*TabPageCallback)(tabPageRequest_T tabPageInfo);
 
+typedef enum
+{
+  MOTION_H,
+  MOTION_L,
+  MOTION_M,
+} screenLineMotion_T;
+typedef void (*CursorMoveScreenLineCallback)(screenLineMotion_T motion, int count, linenr_T startLine, linenr_T *destLine);
+
 typedef struct
 {
   sds contents;

--- a/src/structs.h
+++ b/src/structs.h
@@ -162,6 +162,7 @@ typedef void (*CursorMoveScreenLineCallback)(screenLineMotion_T motion, int coun
 
 typedef void (*CursorMoveScreenPositionCallback)(
     int direction, int count, linenr_T lnum, colnr_T cursor,
+    colnr_T curswant,
     linenr_T *destLnum, colnr_T *destCol);
 
 typedef struct


### PR DESCRIPTION
Since the consumer of libvim owns the rendering (and things like wrapping), `libvim` needs a way to figure out where motions dependent on the view need to go, for example:
- `H`, `L`, `M` - needs to know which line the cursor should move to
- `gj`, `gk` - needs to know where the cursor should move (could be within a a wrapped line)

This sets up callbacks for each of these cases, so the consumer can give context about where the motion should take the cursor. 

Related: https://github.com/onivim/oni2/pull/2578