### PR TITLE
Fix: Unexpected centering when navigating newly opened buffer

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1634,8 +1634,8 @@ void enter_buffer(buf_T *buf)
   check_arg_idx(curwin); /* check for valid arg_idx */
 
   /* when autocmds didn't change it */
-  if (curwin->w_topline == 1 && !curwin->w_topline_was_set)
-    scroll_cursor_halfway(FALSE); /* redisplay at correct position */
+  //  if (curwin->w_topline == 1 && !curwin->w_topline_was_set)
+  //    scroll_cursor_halfway(FALSE); /* redisplay at correct position */
 
   /* Change directories when the 'acd' option is set. */
   DO_AUTOCHDIR;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1633,10 +1633,6 @@ void enter_buffer(buf_T *buf)
 
   check_arg_idx(curwin); /* check for valid arg_idx */
 
-  /* when autocmds didn't change it */
-  //  if (curwin->w_topline == 1 && !curwin->w_topline_was_set)
-  //    scroll_cursor_halfway(FALSE); /* redisplay at correct position */
-
   /* Change directories when the 'acd' option is set. */
   DO_AUTOCHDIR;
 #ifdef FEAT_KEYMAP


### PR DESCRIPTION
__Issue:__ When opening a new buffer for the first time, and navigating around it (ie, `G`), a `SCROLL_CURSOR_CENTERV` is dispatched. This is a bit jarring when using a command like `G` - it's not expected the cursor would be centered, too.

__Fix:__ Remove the cursor-centering from the buffer enter path.
