### PR TITLE
fix(cmdline/#226): Search crash when calling `vimSearchGetHighlights` after closing search

### DIFF
--- a/src/apitest/cmdline_search.c
+++ b/src/apitest/cmdline_search.c
@@ -109,7 +109,6 @@ MU_TEST(test_get_search_highlights_during_visual)
   vimInput(":s/vvvv");
   vimKey("<esc>");
 
-  printf("--- BEFORE searchGetHighlights call2.\n");
   vimSearchGetHighlights(1, 3, &vim_num_search_highlights, &vim_search_highlights);
 }
 

--- a/src/apitest/cmdline_search.c
+++ b/src/apitest/cmdline_search.c
@@ -98,6 +98,21 @@ MU_TEST(test_cancel_n)
   mu_check(vimCursorGetColumn() == 29);
 }
 
+MU_TEST(test_get_search_highlights_during_visual)
+{
+  int vim_num_search_highlights;
+  searchHighlight_T *vim_search_highlights;
+
+  vimInput("V");
+  vimKey("<down>");
+  vimKey("<down>");
+  vimInput(":s/vvvv");
+  vimKey("<esc>");
+
+  printf("--- BEFORE searchGetHighlights call2.\n");
+  vimSearchGetHighlights(1, 3, &vim_num_search_highlights, &vim_search_highlights);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -105,6 +120,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_cancel_inc_search);
   MU_RUN_TEST(test_search_forward_esc);
   MU_RUN_TEST(test_cancel_n);
+  MU_RUN_TEST(test_get_search_highlights_during_visual);
 }
 
 int main(int argc, char **argv)

--- a/src/search.c
+++ b/src/search.c
@@ -136,7 +136,6 @@ int search_regcomp(
     int options,
     regmmatch_T *regmatch) /* return: pattern and ignore-case flag */
 {
-  printf("-- search_regcomp - start 1\n");
   int magic;
   int i;
 

--- a/src/search.c
+++ b/src/search.c
@@ -136,6 +136,7 @@ int search_regcomp(
     int options,
     regmmatch_T *regmatch) /* return: pattern and ignore-case flag */
 {
+  printf("-- search_regcomp - start 1\n");
   int magic;
   int i;
 
@@ -182,7 +183,7 @@ int search_regcomp(
 
     rev_pattern = reverse_text(pat);
     if (rev_pattern == NULL)
-      mr_pattern = pat; /* out of memory, keep normal pattern. */
+      mr_pattern = strdup(pat); /* out of memory, keep normal pattern. */
     else
     {
       mr_pattern = rev_pattern;
@@ -191,7 +192,7 @@ int search_regcomp(
   }
   else
 #endif
-    mr_pattern = pat;
+    mr_pattern = strdup(pat);
 
   /*
      * Save the currently used pattern in the appropriate place,

--- a/src/search.c
+++ b/src/search.c
@@ -651,9 +651,9 @@ int searchit(
   if (search_regcomp(pat, RE_SEARCH, pat_use,
                      (options & (SEARCH_HIS + SEARCH_KEEP)), &regmatch) == FAIL)
   {
-    // TODO:
-    //    if ((options & SEARCH_MSG) && !rc_did_emsg)
-    //      semsg(_("E383: Invalid search string: %s"), mr_pattern);
+    if ((options & SEARCH_MSG) && !rc_did_emsg)
+      semsg(_("E383: Invalid search string: %s"), mr_pattern);
+
     return FAIL;
   }
 

--- a/src/search.c
+++ b/src/search.c
@@ -96,10 +96,8 @@ static int saved_spats_last_idx = 0;
 static int saved_spats_no_hlsearch = 0;
 #endif
 
-static char_u *mr_pattern = NULL; /* pattern used by search_regcomp() */
-#ifdef FEAT_RIGHTLEFT
+static char_u *mr_pattern = NULL;      /* pattern used by search_regcomp() */
 static int mr_pattern_alloced = FALSE; /* mr_pattern was allocated */
-#endif
 
 #ifdef FEAT_FIND_ID
 /*
@@ -171,13 +169,13 @@ int search_regcomp(
 
   if (pat != mr_pattern)
   {
-#ifdef FEAT_RIGHTLEFT
     if (mr_pattern_alloced)
     {
       vim_free(mr_pattern);
       mr_pattern_alloced = FALSE;
     }
 
+#ifdef FEAT_RIGHTLEFT
     if (curwin->w_p_rl && *curwin->w_p_rlc == 's')
     {
       char_u *rev_pattern;


### PR DESCRIPTION
__Issue:__ There was a use-after-free possible if calling `vimSearchGetHighlights` after closing search.

__Defect:__ When the command line mode is started, we allocate a `context` to hold a bunch of info about the command-line session. Part of this contains a command buffer. During the course of the `:%s` gesture, `mr_pattern` - a global string containing the last search pattern - would be set to point to the command buffer. When the command-line session is complete, the command-line context would be freed - including the command buffer. However, `mr_pattern` would still point to the now-freed pointer.

__Fix:__ When `searchit` is run, make a copy of the string. The lifecycle of `mr_pattern` is already managed by search.

Thanks @city41 for the investigation and great repro!

Fixes #226 