### PR TITLE
fix(options): set backspace crash

### DIFF
--- a/src/apitest/option.c
+++ b/src/apitest/option.c
@@ -190,6 +190,16 @@ MU_TEST(test_opt_runtimepath)
   mu_check(lastOptionSet.type == 0);
 }
 
+MU_TEST(test_opt_backspace_string)
+{
+  vimExecute("set backspace=indent,eol");
+  mu_check(optionSetCount == 1);
+  mu_check(strcmp(lastOptionSet.fullname, "backspace") == 0);
+  mu_check(strcmp(lastOptionSet.shortname, "bs") == 0);
+  mu_check(strcmp(lastOptionSet.stringval, "indent,eol") == 0);
+  mu_check(lastOptionSet.type == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -203,6 +213,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_opt_minimap);
   MU_RUN_TEST(test_opt_smoothscroll);
   MU_RUN_TEST(test_opt_runtimepath);
+  MU_RUN_TEST(test_opt_backspace_string);
 }
 
 int main(int argc, char **argv)

--- a/src/option.c
+++ b/src/option.c
@@ -498,7 +498,7 @@ static struct vimoption options[] =
                                                                                          (char_u *)"light",
 #endif
                                                                                          (char_u *)0L} SCTX_INIT},
-        {"backspace", "bs", P_STRING | P_VI_DEF | P_VIM | P_ONECOMMA | P_NODUP, (char_u *)&p_bs, PV_NONE, {(char_u *)"2", (char_u *)0L} SCTX_INIT},
+        {"backspace", "bs", P_STRING | P_VI_DEF | P_VIM | P_ONECOMMA | P_NODUP, (char_u *)&p_bs, PV_NONE, {(char_u *)"indent,eol,start", (char_u *)0L} SCTX_INIT},
         {"backup", "bk", P_BOOL | P_VI_DEF | P_VIM, (char_u *)&p_bk, PV_NONE, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
         {"backupcopy", "bkc", P_STRING | P_VIM | P_ONECOMMA | P_NODUP, (char_u *)&p_bkc, PV_BKC,
 #ifdef UNIX


### PR DESCRIPTION
__Issue:__ The `:set backspace` command would crash

__Defect:__ The default was incorrect

__Fix:__ Fix default