### PR TITLE
fix(operator): Fix issues with 'gc' comment operator

### DIFF
--- a/src/apitest/toggle_comment.c
+++ b/src/apitest/toggle_comment.c
@@ -10,14 +10,63 @@ void test_setup(void)
   vimInput("g");
   vimInput("g");
   vimInput("0");
-
-  vimOptionSetLineComment("//");
 }
 
 void test_teardown(void) {}
 
+int simulateAddCommentCallback(buf_T *buf, linenr_T start, linenr_T end,
+                               linenr_T *outCount, char_u ***outLines)
+{
+  linenr_T count = end - start + 1;
+  *outCount = count;
+
+  char_u **lines = malloc((sizeof(char_u **)) * count);
+  if (count >= 1)
+  {
+    lines[0] = strdup("//This is the first line of a test file");
+  }
+  if (count >= 2)
+  {
+    lines[1] = strdup("//This is the second line of a test file");
+  }
+
+  if (count >= 3)
+  {
+    lines[2] = strdup("//This is the third line of a test file");
+  }
+
+  *outLines = lines;
+  return OK;
+};
+
+int simulateRemoveCommentCallback(buf_T *buf, linenr_T start, linenr_T end,
+                                  linenr_T *outCount, char_u ***outLines)
+{
+  linenr_T count = end - start + 1;
+  *outCount = count;
+
+  char_u **lines = malloc((sizeof(char_u **)) * count);
+  if (count >= 1)
+  {
+    lines[0] = strdup("This is the first line of a test file");
+  }
+  if (count >= 2)
+  {
+    lines[1] = strdup("This is the second line of a test file");
+  }
+
+  if (count >= 3)
+  {
+    lines[2] = strdup("This is the third line of a test file");
+  }
+
+  *outLines = lines;
+  return OK;
+};
+
 MU_TEST(test_toggle_uncommented)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -30,6 +79,7 @@ MU_TEST(test_toggle_uncommented)
 
 MU_TEST(test_toggle_there_and_back_again)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -39,6 +89,7 @@ MU_TEST(test_toggle_there_and_back_again)
 
   mu_check(strcmp(line, "//This is the first line of a test file") == 0);
 
+  vimSetToggleCommentsCallback(&simulateRemoveCommentCallback);
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -51,6 +102,7 @@ MU_TEST(test_toggle_there_and_back_again)
 
 MU_TEST(test_toggle_uncommented_visual)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("V");
   vimInput("g");
   vimInput("c");
@@ -63,6 +115,7 @@ MU_TEST(test_toggle_uncommented_visual)
 
 MU_TEST(test_toggle_uncommented_visual_multi)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("V");
   vimInput("j");
 
@@ -86,6 +139,7 @@ MU_TEST(test_toggle_uncommented_visual_multi)
 
 MU_TEST(test_toggle_there_and_back_again_visual_multi)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("V");
   vimInput("j");
   vimInput("g");
@@ -104,68 +158,10 @@ MU_TEST(test_toggle_there_and_back_again_visual_multi)
   mu_check(strcmp(line3, "This is the third line of a test file") == 0);
 
   // and back again
+  vimSetToggleCommentsCallback(&simulateRemoveCommentCallback);
 
   vimInput("V");
   vimInput("j");
-  vimInput("g");
-  vimInput("c");
-
-  line1 = vimBufferGetLine(curbuf, 1);
-  printf("LINE1: |%s|\n", line1);
-  mu_check(strcmp(line1, "This is the first line of a test file") == 0);
-
-  line2 = vimBufferGetLine(curbuf, 2);
-  printf("LINE2: |%s|\n", line2);
-  mu_check(strcmp(line2, "This is the second line of a test file") == 0);
-
-  line3 = vimBufferGetLine(curbuf, 3);
-  printf("LINE3: |%s|\n", line3);
-  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
-}
-
-MU_TEST(test_set_line_comment)
-{
-  vimOptionSetLineComment("--");
-  vimInput("g");
-  vimInput("c");
-  vimInput("c");
-
-  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", line);
-
-  mu_check(strcmp(line, "--This is the first line of a test file") == 0);
-}
-
-MU_TEST(test_set_line_comment_multi_there_and_back_again)
-{
-  vimOptionSetLineComment("##");
-  vimInput("V");
-  vimInput("j");
-
-  mu_check(vimCursorGetLine() == 2);
-
-  vimInput("g");
-  vimInput("c");
-
-  char_u *line1 = vimBufferGetLine(curbuf, 1);
-  printf("LINE1: |%s|\n", line1);
-  mu_check(strcmp(line1, "##This is the first line of a test file") == 0);
-
-  char_u *line2 = vimBufferGetLine(curbuf, 2);
-  printf("LINE2: |%s|\n", line2);
-  mu_check(strcmp(line2, "##This is the second line of a test file") == 0);
-
-  char_u *line3 = vimBufferGetLine(curbuf, 3);
-  printf("LINE3: |%s|\n", line3);
-  mu_check(strcmp(line3, "This is the third line of a test file") == 0);
-
-  // and back again
-
-  vimInput("V");
-  vimInput("j");
-
-  mu_check(vimCursorGetLine() == 2);
-
   vimInput("g");
   vimInput("c");
 
@@ -184,6 +180,7 @@ MU_TEST(test_set_line_comment_multi_there_and_back_again)
 
 MU_TEST(test_undo)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -203,6 +200,7 @@ MU_TEST(test_undo)
 
 MU_TEST(test_undo_visual_multi)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("V");
   vimInput("j");
 
@@ -242,6 +240,7 @@ MU_TEST(test_undo_visual_multi)
 
 MU_TEST(test_cursor_toggle_there_and_back_again)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("g");
   vimInput("c");
   vimInput("c");
@@ -250,6 +249,7 @@ MU_TEST(test_cursor_toggle_there_and_back_again)
   mu_check(vimCursorGetColumn() == 0);
 
   // and back again
+  vimSetToggleCommentsCallback(&simulateRemoveCommentCallback);
 
   vimInput("g");
   vimInput("c");
@@ -261,6 +261,7 @@ MU_TEST(test_cursor_toggle_there_and_back_again)
 
 MU_TEST(test_cursor_toggle_there_and_back_again_visual_multi)
 {
+  vimSetToggleCommentsCallback(&simulateAddCommentCallback);
   vimInput("V");
   vimInput("j");
 
@@ -275,6 +276,7 @@ MU_TEST(test_cursor_toggle_there_and_back_again_visual_multi)
 
   // and back again
 
+  vimSetToggleCommentsCallback(&simulateRemoveCommentCallback);
   vimInput("V");
   vimInput("j");
 
@@ -308,8 +310,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_toggle_uncommented_visual);
   MU_RUN_TEST(test_toggle_uncommented_visual_multi);
   MU_RUN_TEST(test_toggle_there_and_back_again_visual_multi);
-  MU_RUN_TEST(test_set_line_comment);
-  MU_RUN_TEST(test_set_line_comment_multi_there_and_back_again);
   MU_RUN_TEST(test_undo);
   MU_RUN_TEST(test_undo_visual_multi);
   MU_RUN_TEST(test_cursor_toggle_there_and_back_again);

--- a/src/globals.h
+++ b/src/globals.h
@@ -67,6 +67,7 @@ EXTERN OptionSetCallback optionSetCallback INIT(= NULL);
 EXTERN QuitCallback quitCallback INIT(= NULL);
 EXTERN ScrollCallback scrollCallback INIT(= NULL);
 EXTERN TerminalCallback terminalCallback INIT(= NULL);
+EXTERN ToggleCommentsCallback toggleCommentsCallback INIT(= NULL);
 EXTERN VoidCallback stopSearchHighlightCallback INIT(= NULL);
 EXTERN VoidCallback unhandledEscapeCallback INIT(= NULL);
 EXTERN WindowSplitCallback windowSplitCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -468,17 +468,6 @@ void vimOptionSetInsertSpaces(int insertSpaces)
   }
 }
 
-void vimOptionSetLineComment(const char_u *str)
-{
-  vim_free(curbuf->b_oni_line_comment);
-  curbuf->b_oni_line_comment = (char_u *)alloc(STRLEN(str) + 1);
-
-  if (curbuf->b_oni_line_comment != NULL)
-  {
-    strcpy(curbuf->b_oni_line_comment, str);
-  }
-}
-
 int vimOptionGetTabSize() { return curbuf->b_p_ts; }
 
 int vimOptionGetInsertSpaces(void) { return curbuf->b_p_et; }
@@ -522,6 +511,11 @@ void vimWindowSetHeight(int height)
 void vimSetClipboardGetCallback(ClipboardGetCallback callback)
 {
   clipboardGetCallback = callback;
+}
+
+void vimSetToggleCommentsCallback(ToggleCommentsCallback callback)
+{
+  toggleCommentsCallback = callback;
 }
 
 int vimGetMode(void) { return get_real_state(); }

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -209,6 +209,12 @@ void vimSetTabPageCallback(TabPageCallback tabPageCallback);
 void vimSetDirectoryChangedCallback(DirectoryChangedCallback callback);
 void vimSetOptionSetCallback(OptionSetCallback callback);
 
+/**
+ * Operators
+ **/
+
+void vimSetToggleCommentsCallback(ToggleCommentsCallback callback);
+
 /*
  * vimSetQuitCallback
  *
@@ -253,7 +259,6 @@ void vimMacroSetStopRecordCallback(MacroStopRecordCallback callback);
 
 void vimOptionSetTabSize(int tabSize);
 void vimOptionSetInsertSpaces(int insertSpaces);
-void vimOptionSetLineComment(char_u *str);
 
 int vimOptionGetInsertSpaces(void);
 int vimOptionGetTabSize(void);

--- a/src/normal.c
+++ b/src/normal.c
@@ -349,48 +349,6 @@ static const struct nv_cmd
 
 #define strstartswith(a, b) (!strncmp(a, b, strlen(b)))
 
-void toggle_comment(linenr_T lnum)
-{
-  //const char_u *comment = curbuf->b_oni_line_comment != NULL ? curbuf->b_oni_line_comment : (char_u *)"//";
-  const char_u *comment = (char_u *)"//";
-  int commentlen = (int)STRLEN(comment);
-  const char_u *line = ml_get(lnum);
-  int linelen = (int)STRLEN(line);
-  char_u *newp;
-
-  if (strstartswith(line, comment))
-  {
-    // remove comment
-
-    newp = alloc((linelen - commentlen) + 1);
-
-    if (newp == NULL)
-      return;
-
-    if (virtual_active() && curwin->w_cursor.coladd > 0)
-      coladvance_force(getviscol());
-
-    mch_memmove(newp, line + commentlen, (size_t)((linelen - commentlen) + 1));
-    ml_replace(lnum, newp, FALSE);
-  }
-  else
-  {
-    // add comment
-
-    newp = alloc(linelen + commentlen + 1);
-
-    if (newp == NULL)
-      return;
-
-    if (virtual_active() && curwin->w_cursor.coladd > 0)
-      coladvance_force(getviscol());
-
-    mch_memmove(newp, comment, (size_t)commentlen);
-    mch_memmove(newp + commentlen, line, (size_t)(linelen + 1));
-    ml_replace(lnum, newp, FALSE);
-  }
-}
-
 void toggle_comment_lines(linenr_T start, linenr_T end)
 {
   linenr_T lnum;

--- a/src/normal.c
+++ b/src/normal.c
@@ -6582,7 +6582,7 @@ static void nv_Undo(cmdarg_T *cap)
 static void nv_c(cmdarg_T *cap)
 {
   /* In Visual mode AND typing "gcc" triggers an operator */
-  if (cap->oap->op_type == OP_COMMENT && VIsual_active)
+  if (cap->oap->op_type == OP_COMMENT)
   {
     /* translate "gcc" to "gcgc" */
     cap->cmdchar = 'g';

--- a/src/structs.h
+++ b/src/structs.h
@@ -2439,7 +2439,6 @@ struct file_buffer
   int b_diff_failed; // internal diff failed for this buffer
 #endif
 
-  char_u *b_oni_line_comment;
 }; /* file_buffer */
 
 /* buffer updates */
@@ -2480,6 +2479,7 @@ typedef void (*MessageCallback)(char_u *title, char_u *msg, msgPriority_T priori
 typedef void (*DirectoryChangedCallback)(char_u *path);
 typedef void (*QuitCallback)(buf_T *buf, int isForced);
 typedef void (*OptionSetCallback)(optionSet_T *optionSet);
+typedef int (*ToggleCommentsCallback)(buf_T *buf, linenr_T startLine, linenr_T endLine, linenr_T *outCount, char_u ***outLines);
 
 #ifdef FEAT_DIFF
 /*


### PR DESCRIPTION
- Fix `get_op_type` error (https://github.com/onivim/oni2/issues/2409)
- Externalize comment toggle transform