### PR TITLE
feat(eval): Add callback to listen to let expression

### DIFF
--- a/src/apitest/eval.c
+++ b/src/apitest/eval.c
@@ -2,6 +2,19 @@
 #include "libvim.h"
 #include "minunit.h"
 
+void onEvalVariableSet(char_u *name, typval_T *val)
+{
+  if (val->v_type == VAR_STRING)
+  {
+    printf("%s set: %s\n", name, val->vval.v_string);
+  }
+  else if (val->v_type == VAR_NUMBER)
+  {
+
+    printf("%s set: %ld\n", name, val->vval.v_number);
+  }
+}
+
 void test_setup(void)
 {
   vimKey("<esc>");
@@ -30,17 +43,29 @@ MU_TEST(test_empty)
   mu_check(result == NULL);
 }
 
+MU_TEST(test_let_expression)
+{
+  vimExecute("let mapleader = \"<space>\"");
+  vimExecute("let g:mapleader = \"<space>\"");
+  vimExecute("let mapleader = 1");
+
+  mu_check(TRUE);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_simple_addition);
   MU_RUN_TEST(test_empty);
+  MU_RUN_TEST(test_let_expression);
 }
 
 int main(int argc, char **argv)
 {
   vimInit(argc, argv);
+
+  vimSetEvalVariableSetCallback(&onEvalVariableSet);
 
   win_setwidth(5);
   win_setheight(100);

--- a/src/eval.c
+++ b/src/eval.c
@@ -2341,7 +2341,6 @@ set_var_lval(
   int cc;
   listitem_T *ri;
   dictitem_T *di;
-
   if (lp->ll_tv == NULL)
   {
     cc = *endp;
@@ -7893,6 +7892,13 @@ void set_var(
     typval_T *tv,
     int copy) /* make copy of value in "tv" */
 {
+
+  if (name != NULL && tv != NULL)
+  {
+    //printf("lp->ll_exp_name: %s\n", lp->ll_exp_name);
+    evalVariableSetCallback(name, tv);
+  }
+
   dictitem_T *v;
   char_u *varname;
   hashtab_T *ht;

--- a/src/globals.h
+++ b/src/globals.h
@@ -50,6 +50,7 @@ EXTERN BufferUpdateCallback bufferUpdateCallback INIT(= NULL);
 EXTERN ClipboardGetCallback clipboardGetCallback INIT(= NULL);
 EXTERN FileWriteFailureCallback fileWriteFailureCallback INIT(= NULL);
 EXTERN DirectoryChangedCallback directoryChangedCallback INIT(= NULL);
+EXTERN EvalVariableSetCallback evalVariableSetCallback INIT(= NULL);
 EXTERN FormatCallback formatCallback INIT(= NULL);
 EXTERN GotoCallback gotoCallback INIT(= NULL);
 EXTERN TabPageCallback tabPageCallback INIT(= NULL);

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -175,6 +175,11 @@ void vimSetDirectoryChangedCallback(DirectoryChangedCallback f)
   directoryChangedCallback = f;
 }
 
+void vimSetEvalVariableSetCallback(EvalVariableSetCallback f)
+{
+  evalVariableSetCallback = f;
+}
+
 void vimSetOptionSetCallback(OptionSetCallback f)
 {
   optionSetCallback = f;

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -107,6 +107,8 @@ void vimCommandLineGetCompletions(char_u ***completions, int *count);
  */
 char_u *vimEval(char_u *str);
 
+void vimSetEvalVariableSetCallback(EvalVariableSetCallback callback);
+
 /***
  * Cursor Methods
  ***/

--- a/src/structs.h
+++ b/src/structs.h
@@ -1390,6 +1390,8 @@ typedef struct
   } vval;
 } typval_T;
 
+typedef void (*EvalVariableSetCallback)(char_u *name, typval_T *tv);
+
 /* Values for "dv_scope". */
 #define VAR_SCOPE 1 /* a:, v:, s:, etc. scope dictionaries */
 


### PR DESCRIPTION
The idea would be that the libvim consumer could listen for `let mapleader="<space>"` or similar expressions, which is needed since input mapping is externalizd.