### PR TITLE
fix(edit): Insert-mode count

### DIFF
--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -229,7 +229,8 @@ MU_TEST(insert_mode_arrow_key_join_undo)
   mu_check(vimBufferGetLineCount(curbuf) == initialLineCount);
 }
 
-MU_TEST(insert_mode_test_count_i) {
+MU_TEST(insert_mode_test_count_i)
+{
   vimKey("3");
   vimKey("i");
 
@@ -240,7 +241,8 @@ MU_TEST(insert_mode_test_count_i) {
   mu_check(strcmp(line, "abcabcabcThis is the first line of a test file") == 0);
 }
 
-MU_TEST(insert_mode_test_count_A) {
+MU_TEST(insert_mode_test_count_A)
+{
   vimKey("4");
   vimKey("A");
 
@@ -251,7 +253,8 @@ MU_TEST(insert_mode_test_count_A) {
   mu_check(strcmp(line, "This is the first line of a test fileabcabcabcabc") == 0);
 }
 
-MU_TEST(insert_mode_test_count_O) {
+MU_TEST(insert_mode_test_count_O)
+{
   vimKey("2");
   vimKey("O");
 

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -3,6 +3,8 @@
 
 void test_setup(void)
 {
+  (void)vimBufferOpen("collateral/testfile.txt", 1, 0);
+
   vimKey("<Esc>");
   vimKey("<Esc>");
   vimExecute("e!");
@@ -251,6 +253,50 @@ MU_TEST(insert_mode_arrow_key_join_undo)
   mu_check(vimBufferGetLineCount(curbuf) == initialLineCount);
 }
 
+MU_TEST(insert_mode_test_count_i) {
+  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", beforeLine);
+  vimKey("3");
+  vimKey("i");
+
+  vimInput("abc");
+  vimKey("<esc>");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  mu_check(strcmp(line, "abcabcabcThis is the first line of a test file") == 0);
+}
+
+MU_TEST(insert_mode_test_count_A) {
+  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", beforeLine);
+  vimKey("4");
+  vimKey("A");
+
+  vimInput("abc");
+  vimKey("<esc>");
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  mu_check(strcmp(line, "This is the first line of a test fileabcabcabcabc") == 0);
+}
+
+MU_TEST(insert_mode_test_count_O) {
+  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", beforeLine);
+  vimKey("2");
+  vimKey("O");
+
+  vimInput("abc");
+  vimKey("<esc>");
+
+  char_u *line1 = vimBufferGetLine(curbuf, 1);
+  mu_check(strcmp(line1, "abc") == 0);
+
+  char_u *line2 = vimBufferGetLine(curbuf, 1);
+  mu_check(strcmp(line2, "abc") == 0);
+
+  mu_check(vimBufferGetLineCount(curbuf) == 5);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -269,6 +315,9 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_mode_utf8_special_byte);
   MU_RUN_TEST(insert_mode_arrow_breaks_undo);
   MU_RUN_TEST(insert_mode_arrow_key_join_undo);
+  MU_RUN_TEST(insert_mode_test_count_i);
+  MU_RUN_TEST(insert_mode_test_count_A);
+  MU_RUN_TEST(insert_mode_test_count_O);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -16,19 +16,6 @@ void test_setup(void)
 
 void test_teardown(void) {}
 
-/* TODO: Get this test green */
-/* MU_TEST(insert_count) { */
-/*   vimInput("5"); */
-/*   vimInput("i"); */
-/*   vimInput("a"); */
-/*   vimInput("\033"); */
-
-/*   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine()); */
-/*   printf("LINE: %s\n", line); */
-/*   mu_check(strcmp(line, "aaaaaThis is the first line of a test file") == 0);
- */
-/* } */
-
 MU_TEST(insert_beginning)
 {
   vimInput("I");
@@ -37,7 +24,6 @@ MU_TEST(insert_beginning)
   vimInput("c");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, "abcThis is the first line of a test file") == 0);
 }
 
@@ -66,8 +52,6 @@ MU_TEST(insert_prev_line)
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
-  printf("LINE: %s\n", line);
-
   mu_check(strcmp(line, "abc") == 0);
 }
 
@@ -82,8 +66,6 @@ MU_TEST(insert_next_line)
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
-  printf("LINE: %s\n", line);
-
   mu_check(strcmp(line, "abc") == 0);
 }
 MU_TEST(insert_end)
@@ -93,8 +75,6 @@ MU_TEST(insert_end)
   vimInput("b");
   vimInput("c");
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-
-  printf("LINE: %s\n", line);
 
   mu_check(strcmp(line, "This is the first line of a test fileabc") == 0);
 }
@@ -136,7 +116,6 @@ MU_TEST(insert_mode_ctrlv)
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, "~") == 0);
 }
 
@@ -152,7 +131,6 @@ MU_TEST(insert_mode_ctrlv_no_digit)
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
 
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, "a") == 0);
 }
 
@@ -178,7 +156,6 @@ MU_TEST(insert_mode_utf8)
   vimInput("κόσμε");
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, "κόσμε") == 0);
 }
 
@@ -196,7 +173,6 @@ MU_TEST(insert_mode_utf8_special_byte)
   vimInput(input);
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, input) == 0);
 }
 
@@ -254,8 +230,6 @@ MU_TEST(insert_mode_arrow_key_join_undo)
 }
 
 MU_TEST(insert_mode_test_count_i) {
-  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", beforeLine);
   vimKey("3");
   vimKey("i");
 
@@ -267,8 +241,6 @@ MU_TEST(insert_mode_test_count_i) {
 }
 
 MU_TEST(insert_mode_test_count_A) {
-  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", beforeLine);
   vimKey("4");
   vimKey("A");
 
@@ -280,8 +252,6 @@ MU_TEST(insert_mode_test_count_A) {
 }
 
 MU_TEST(insert_mode_test_count_O) {
-  char_u *beforeLine = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", beforeLine);
   vimKey("2");
   vimKey("O");
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -643,8 +643,9 @@ executionStatus_T state_edit_execute(void *ctx, int c)
       return COMPLETED;
       /* TODO: Handle Ctrl_O */
       /* return (c == Ctrl_O); */
+    } else {
+      return HANDLED;
     }
-    return COMPLETED;
 
   case Ctrl_Z: /* suspend when 'insertmode' set */
     if (!p_im)

--- a/src/edit.c
+++ b/src/edit.c
@@ -643,7 +643,9 @@ executionStatus_T state_edit_execute(void *ctx, int c)
       return COMPLETED;
       /* TODO: Handle Ctrl_O */
       /* return (c == Ctrl_O); */
-    } else {
+    }
+    else
+    {
       return HANDLED;
     }
 


### PR DESCRIPTION
__Issue:__ When using a count with insert mode commands (ie, `3i`, `5o`, etc) - the behavior was unexpected.

__Defect:__ We were leaving insert mode prior to fully replaying the commands.

__Fix:__ Stay in insert mode until the repeat is complete. Add test cases to cover.