### PR TITLE
fix(insert): Fix restart_edit behavior (ctrl+o)

### DIFF
--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -316,6 +316,23 @@ MU_TEST(insert_mode_test_ctrl_o_delete)
   mu_check(vimBufferGetLineCount(curbuf) < startingLineCount);
 }
 
+MU_TEST(insert_mode_test_ctrl_o_change)
+{
+  vimKey("i");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+  mu_check(vimCursorGetLine() == 1);
+
+  vimKey("<c-o>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
+
+  vimKey("C");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  printf("LINE: %s\n", line);
+  mu_check(strcmp(line, "") == 0);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -340,6 +357,7 @@ MU_TEST_SUITE(test_suite)
 
   MU_RUN_TEST(insert_mode_test_ctrl_o_motion);
   MU_RUN_TEST(insert_mode_test_ctrl_o_delete);
+  MU_RUN_TEST(insert_mode_test_ctrl_o_change);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -282,6 +282,22 @@ MU_TEST(insert_mode_test_count_O)
   mu_check(vimBufferGetLineCount(curbuf) == 5);
 }
 
+MU_TEST(insert_mode_test_ctrl_o)
+{
+  vimKey("I");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+  mu_check(vimCursorGetLine() == 1);
+
+  vimKey("<c-o>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
+
+  printf("RESTART_EDIT: %c\n", restart_edit);
+
+  vimKey("j");
+  mu_check(vimCursorGetLine() == 2);
+  mu_check((vimGetMode() & INSERT) == INSERT);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -303,6 +319,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_mode_test_count_i);
   MU_RUN_TEST(insert_mode_test_count_A);
   MU_RUN_TEST(insert_mode_test_count_O);
+
+  MU_RUN_TEST(insert_mode_test_ctrl_o);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -291,8 +291,6 @@ MU_TEST(insert_mode_test_ctrl_o_motion)
   vimKey("<c-o>");
   mu_check((vimGetMode() & NORMAL) == NORMAL);
 
-  printf("RESTART_EDIT: %c\n", restart_edit);
-
   vimKey("j");
   mu_check(vimCursorGetLine() == 2);
   mu_check((vimGetMode() & INSERT) == INSERT);
@@ -316,6 +314,22 @@ MU_TEST(insert_mode_test_ctrl_o_delete)
   mu_check(vimBufferGetLineCount(curbuf) < startingLineCount);
 }
 
+MU_TEST(insert_mode_test_ctrl_o_delete_translate)
+{
+  vimKey("I");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+  mu_check(vimCursorGetLine() == 1);
+
+  vimKey("<c-o>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
+
+  vimKey("D");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+
+  char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
+  mu_check(strcmp(line, "") == 0);
+}
+
 MU_TEST(insert_mode_test_ctrl_o_change)
 {
   vimKey("i");
@@ -329,7 +343,6 @@ MU_TEST(insert_mode_test_ctrl_o_change)
   mu_check((vimGetMode() & INSERT) == INSERT);
 
   char_u *line = vimBufferGetLine(curbuf, vimCursorGetLine());
-  printf("LINE: %s\n", line);
   mu_check(strcmp(line, "") == 0);
 }
 
@@ -357,6 +370,7 @@ MU_TEST_SUITE(test_suite)
 
   MU_RUN_TEST(insert_mode_test_ctrl_o_motion);
   MU_RUN_TEST(insert_mode_test_ctrl_o_delete);
+  MU_RUN_TEST(insert_mode_test_ctrl_o_delete_translate);
   MU_RUN_TEST(insert_mode_test_ctrl_o_change);
 }
 

--- a/src/apitest/insert_mode.c
+++ b/src/apitest/insert_mode.c
@@ -282,7 +282,7 @@ MU_TEST(insert_mode_test_count_O)
   mu_check(vimBufferGetLineCount(curbuf) == 5);
 }
 
-MU_TEST(insert_mode_test_ctrl_o)
+MU_TEST(insert_mode_test_ctrl_o_motion)
 {
   vimKey("I");
   mu_check((vimGetMode() & INSERT) == INSERT);
@@ -296,6 +296,24 @@ MU_TEST(insert_mode_test_ctrl_o)
   vimKey("j");
   mu_check(vimCursorGetLine() == 2);
   mu_check((vimGetMode() & INSERT) == INSERT);
+}
+
+MU_TEST(insert_mode_test_ctrl_o_delete)
+{
+  int startingLineCount = vimBufferGetLineCount(curbuf);
+  vimKey("I");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+  mu_check(vimCursorGetLine() == 1);
+
+  vimKey("<c-o>");
+  mu_check((vimGetMode() & NORMAL) == NORMAL);
+
+  vimKey("d");
+  mu_check((vimGetMode() & INSERT) != INSERT);
+  vimKey("d");
+  mu_check((vimGetMode() & INSERT) == INSERT);
+
+  mu_check(vimBufferGetLineCount(curbuf) < startingLineCount);
 }
 
 MU_TEST_SUITE(test_suite)
@@ -320,7 +338,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(insert_mode_test_count_A);
   MU_RUN_TEST(insert_mode_test_count_O);
 
-  MU_RUN_TEST(insert_mode_test_ctrl_o);
+  MU_RUN_TEST(insert_mode_test_ctrl_o_motion);
+  MU_RUN_TEST(insert_mode_test_ctrl_o_delete);
 }
 
 int main(int argc, char **argv)

--- a/src/normal.c
+++ b/src/normal.c
@@ -970,11 +970,8 @@ restart_state:
       do_pending_operator(&context->ca, context->old_col, FALSE);
     }
 
-    if (restart_edit != 0) {
-      restart_edit = 0;
-      if (stuff_empty()) {
+    if (restart_edit != 0 && stuff_empty()) {
         sm_push_insert('i', FALSE, context->ca.count1);
-      }
     }
 
     /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -918,11 +918,6 @@ restart_state:
 
     finish_op = (oap->op_type != OP_NOP);
 
-    if (restart_edit != 0) {
-      restart_edit = 0;
-      sm_push_insert('i', FALSE, context->ca.count1);
-    }
-
     int stateMode = sm_get_current_mode();
     if (stateMode != NORMAL)
     {
@@ -973,6 +968,11 @@ restart_state:
     if (finish_op || VIsual_active)
     {
       do_pending_operator(&context->ca, context->old_col, FALSE);
+    }
+
+    if (restart_edit != 0) {
+      restart_edit = 0;
+      sm_push_insert('i', FALSE, context->ca.count1);
     }
 
     /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -970,8 +970,9 @@ restart_state:
       do_pending_operator(&context->ca, context->old_col, FALSE);
     }
 
-    if (restart_edit != 0 && stuff_empty()) {
-        sm_push_insert('i', FALSE, context->ca.count1);
+    if (restart_edit != 0 && stuff_empty())
+    {
+      sm_push_insert('i', FALSE, context->ca.count1);
     }
 
     /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -918,6 +918,11 @@ restart_state:
 
     finish_op = (oap->op_type != OP_NOP);
 
+    if (restart_edit != 0) {
+      restart_edit = 0;
+      sm_push_insert('i', FALSE, context->ca.count1);
+    }
+
     int stateMode = sm_get_current_mode();
     if (stateMode != NORMAL)
     {

--- a/src/normal.c
+++ b/src/normal.c
@@ -972,7 +972,9 @@ restart_state:
 
     if (restart_edit != 0) {
       restart_edit = 0;
-      sm_push_insert('i', FALSE, context->ca.count1);
+      if (stuff_empty()) {
+        sm_push_insert('i', FALSE, context->ca.count1);
+      }
     }
 
     /*


### PR DESCRIPTION
This implements basic functionality for `ctrl+o` in the context of the revised state machine

Related https://github.com/onivim/oni2/issues/2425