### PR TITLE
fix(visual): Retain behavior for A/I in non-block visual mode

### DIFF
--- a/src/apitest/visual_mode_operator.c
+++ b/src/apitest/visual_mode_operator.c
@@ -53,6 +53,24 @@ MU_TEST(test_visual_character_delete)
   mu_check(strcmp(line, "is is the first line of a test file") == 0);
 }
 
+MU_TEST(test_visual_character_insert)
+{
+  vimInput("v");
+  vimInput("j");
+  vimInput("I");
+
+  mu_check((vimGetMode() & INSERT) == INSERT);
+}
+
+MU_TEST(test_visual_linewise_append)
+{
+  vimInput("V");
+  vimInput("j");
+  vimInput("A");
+
+  mu_check((vimGetMode() & INSERT) == INSERT);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -60,6 +78,8 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_visual_linewise_delete);
   MU_RUN_TEST(test_visual_linewise_motion_delete);
   MU_RUN_TEST(test_visual_character_delete);
+  MU_RUN_TEST(test_visual_character_insert);
+  MU_RUN_TEST(test_visual_linewise_append);
 }
 
 int main(int argc, char **argv)

--- a/src/normal.c
+++ b/src/normal.c
@@ -6412,7 +6412,8 @@ static void nv_edit(cmdarg_T *cap)
     }
 #endif
     // Block 'I'insert or 'A'ppend - special case to produce multiple cursors
-    if (VIsual_mode == Ctrl_V) {
+    if (VIsual_mode == Ctrl_V)
+    {
       was_visual_block = 1;
       int minCol = VIsual.col;
       if (minCol > curwin->w_cursor.col)
@@ -6467,7 +6468,9 @@ static void nv_edit(cmdarg_T *cap)
       curwin->w_cursor = originalPos;
       clearop(cap->oap);
       invoke_edit(cap, FALSE, cap->cmdchar, FALSE);
-    } else {
+    }
+    else
+    {
       // Not block - default to original Vim behavior:
       end_visual_mode();
       clearop(cap->oap);
@@ -6477,7 +6480,7 @@ static void nv_edit(cmdarg_T *cap)
 
   /* in Visual mode and after an operator "a" and "i" are for text objects */
   if ((cap->cmdchar == 'a' || cap->cmdchar == 'i') &&
-           (cap->oap->op_type != OP_NOP || VIsual_active))
+      (cap->oap->op_type != OP_NOP || VIsual_active))
   {
 #ifdef FEAT_TEXTOBJ
     nv_object(cap);


### PR DESCRIPTION
__Issue:__ The #167 cursor changed callback behavior regressed the 'A' and 'I' behavior for non-block visual modes (character, line)

__Defect:__ We were consuming that case in our new multi-cursor entry point

__Fix:__ Keep that particular case split out as before, add a test to cover