### PR TITLE
feat(api): Add buffer to vimSearchGetHighlights API

### DIFF
--- a/src/apitest/cmdline_search.c
+++ b/src/apitest/cmdline_search.c
@@ -109,7 +109,7 @@ MU_TEST(test_get_search_highlights_during_visual)
   vimInput(":s/vvvv");
   vimKey("<esc>");
 
-  vimSearchGetHighlights(1, 3, &vim_num_search_highlights, &vim_search_highlights);
+  vimSearchGetHighlights(curbuf, 1, 3, &vim_num_search_highlights, &vim_search_highlights);
 }
 
 MU_TEST(test_insert_literal_ctrl_v)

--- a/src/apitest/search_highlights.c
+++ b/src/apitest/search_highlights.c
@@ -104,7 +104,7 @@ MU_TEST(test_highlights_multiple_buffers)
   vimInput("n");
   vimInput("e");
 
-  buf_T* originalBuffer = curbuf;
+  buf_T *originalBuffer = curbuf;
 
   // Switch to an alternate file
   vimBufferOpen("collateral/lines_100.txt", 1, 0);

--- a/src/apitest/search_large_file.c
+++ b/src/apitest/search_large_file.c
@@ -18,14 +18,11 @@ MU_TEST(test_search_in_large_file)
 {
 
   vimInput("/");
-  printf("Typing e...\n");
   vimInput("e");
-  printf("Typed e! \n");
 
   int num;
   searchHighlight_T *highlights;
-  vimSearchGetHighlights(0, 0, &num, &highlights);
-  printf("Got %d highlights\n", num);
+  vimSearchGetHighlights(curbuf, 0, 0, &num, &highlights);
   vim_free(highlights);
   mu_check(num == 15420);
 }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -359,7 +359,7 @@ struct shlNode_elem
   shlNode_T *next;
 };
 
-void vimSearchGetHighlights(linenr_T start_lnum, linenr_T end_lnum,
+void vimSearchGetHighlights(buf_T *buf, linenr_T start_lnum, linenr_T end_lnum,
                             int *num_highlights,
                             searchHighlight_T **highlights)
 {
@@ -389,7 +389,7 @@ void vimSearchGetHighlights(linenr_T start_lnum, linenr_T end_lnum,
 
   while (v == 1)
   {
-    v = searchit(NULL, curbuf, &startPos, &endPos, FORWARD, pattern, 1,
+    v = searchit(NULL, buf, &startPos, &endPos, FORWARD, pattern, 1,
                  SEARCH_KEEP, RE_SEARCH, end_lnum, NULL, NULL);
 
     if (v == 0)

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -362,7 +362,7 @@ pos_T *vimSearchGetMatchingPair(int initc);
  *
  * Get highlights for the current search
  */
-void vimSearchGetHighlights(linenr_T start_lnum, linenr_T end_lnum,
+void vimSearchGetHighlights(buf_T *buf, linenr_T start_lnum, linenr_T end_lnum,
                             int *num_highlights,
                             searchHighlight_T **highlights);
 


### PR DESCRIPTION
__Issue:__ The `vimSearchGetHighlights` API was implicitly scoped to the current buffer.

__Defect:__ With the current API, it isn't straightforward to get highlights for all visible buffers.

__Fix:__ Allow passing in a buffer instead of implicitly using the current buffer for `vimSearchGetHighlights`