### PR TITLE
fix(search): Disable confirm flag

### DIFF
--- a/src/apitest/basic_cmdline_tests.c
+++ b/src/apitest/basic_cmdline_tests.c
@@ -136,6 +136,28 @@ MU_TEST(test_cmdline_substitution)
                   "Ahis is the first line of a test file") == 0);
 }
 
+MU_TEST(test_cmdline_substitution_confirm)
+{
+  buf_T *buffer = vimBufferGetCurrent();
+  int lc = vimBufferGetLineCount(buffer);
+  mu_check(lc == 3);
+
+  vimInput(":");
+  vimInput("s");
+  vimInput("!");
+  vimInput("T");
+  vimInput("!");
+  vimInput("A");
+  vimInput("!");
+  vimInput("g");
+  vimInput("g");
+  vimInput("c");
+  vimKey("<cr>");
+
+  mu_check(strcmp(vimBufferGetLine(buffer, 1),
+                  "This is the first line of a test file") == 0);
+}
+
 MU_TEST(test_cmdline_get_type)
 {
   vimInput(":");
@@ -162,6 +184,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_cmdline_enter);
   MU_RUN_TEST(test_cmdline_execute);
   MU_RUN_TEST(test_cmdline_substitution);
+  MU_RUN_TEST(test_cmdline_substitution_confirm);
   MU_RUN_TEST(test_cmdline_get_type);
 }
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4846,7 +4846,8 @@ void do_sub(exarg_T *eap)
 
   // HACK: For now, instead of hanging / hitting a block input path... at least let the user know what went wrong.
   // Next step: Implement a state machine so we can handle confirm without blocking.
-  if (subflags.do_ask) {
+  if (subflags.do_ask)
+  {
     emsg("libvim: Confirm flag (c) is not currently supported for substitution.");
     return;
   }

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4596,7 +4596,7 @@ typedef struct
   int do_ic;     /* ignore case flag */
 } subflags_T;
 
-/* do_sub()
+/* mo_sub()
  *
  * Perform a substitution from line eap->line1 to line eap->line2 using the
  * command pointed to by eap->arg which should be of the form:
@@ -4843,6 +4843,13 @@ void do_sub(exarg_T *eap)
   }
   if (subflags.do_count)
     subflags.do_ask = FALSE;
+
+  // HACK: For now, instead of hanging / hitting a block input path... at least let the user know what went wrong.
+  // Next step: Implement a state machine so we can handle confirm without blocking.
+  if (subflags.do_ask) {
+    emsg("libvim: Confirm flag (c) is not currently supported for substitution.");
+    return;
+  }
 
   save_do_all = subflags.do_all;
   save_do_ask = subflags.do_ask;


### PR DESCRIPTION
__Issue:__ In `libvim`, trying to run the `sub` ex command with the confirm flag will enter a blocking input mode, causing a hang.

__Defect:__ The confirm code path hasn't been factored out to a non-blocking state machine

__Fix:__ For now, show an error message saying that confirm isn't currently supported. This is at least better than hanging / crashing. Ideally, though, a future fix would be to implement the confirm behavior as a state machine.