### PR TITLE
fix(viml): Handle ex_function correctly

### DIFF
--- a/src/apitest/cmdline.c
+++ b/src/apitest/cmdline.c
@@ -82,6 +82,27 @@ MU_TEST(test_valid_multiline_command)
   vim_free(result);
 }
 
+MU_TEST(test_multiline_multiple_functions)
+{
+  mu_check(messageCount == 0);
+
+  char_u *lines[] = {
+      "function! SomeCommandTest()",
+      "return 42",
+      "endfunction",
+      "function! AnotherFunction()",
+      "return 99",
+      "endfunction"};
+
+  vimExecuteLines(lines, 6);
+  mu_check(messageCount == 0);
+
+  char_u *result = vimEval("AnotherFunction()");
+  printf("Got result: %s\n", result);
+  mu_check(strcmp(result, "99") == 0);
+  vim_free(result);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -91,6 +112,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_typing_function_command);
   MU_RUN_TEST(test_multiline_command_sends_message);
   MU_RUN_TEST(test_valid_multiline_command);
+  MU_RUN_TEST(test_multiline_multiple_functions);
 }
 
 int main(int argc, char **argv)

--- a/src/apitest/cmdline.c
+++ b/src/apitest/cmdline.c
@@ -48,22 +48,22 @@ MU_TEST(test_insert_literal_ctrl_q)
 }
 
 
-// MU_TEST(test_typing_function_command)
-// {
-//   vimInput(":");
-//   vimInput("function! Test()");
-  // TODO: Fix
-  // vimKey("<CR>");
+MU_TEST(test_typing_function_command)
+{
+  vimInput(":");
+  vimInput("function! Test()");
+  vimKey("<CR>");
+  //Should get an error message for multiline construct
+  mu_check(messageCount == 1);
+}
+
+MU_TEST(test_multiline_command_sends_message) 
+{
+  mu_check(messageCount == 0);
+  vimExecute("function! Test()");
   // Should get an error message for multiline construct
-//   mu_check(messageCount == 1);
-// }
-// MU_TEST(test_multiline_command_sends_message) 
-// {
-//   mu_check(messageCount == 0);
-//   vimExecute("function! Test()");
-  // Should get an error message for multiline construct
-//   mu_check(messageCount == 1);
-// }
+  mu_check(messageCount == 1);
+}
 
 MU_TEST(test_valid_multiline_command)
 {
@@ -90,8 +90,8 @@ MU_TEST_SUITE(test_suite)
 
   MU_RUN_TEST(test_insert_literal_ctrl_v);
   MU_RUN_TEST(test_insert_literal_ctrl_q);
-  //MU_RUN_TEST(test_typing_function_command);
-  //MU_RUN_TEST(test_multiline_command_sends_message);
+  MU_RUN_TEST(test_typing_function_command);
+  MU_RUN_TEST(test_multiline_command_sends_message);
   MU_RUN_TEST(test_valid_multiline_command);
 }
 

--- a/src/apitest/cmdline.c
+++ b/src/apitest/cmdline.c
@@ -1,6 +1,13 @@
 #include "libvim.h"
 #include "minunit.h"
 
+int messageCount = 0;
+void onMessage(char_u *title, char_u *msg, msgPriority_T priority)
+{
+  printf("onMessage - title: |%s| contents: |%s|", title, msg);
+  messageCount++;
+};
+
 void test_setup(void)
 {
   vimKey("<esc>");
@@ -10,6 +17,8 @@ void test_setup(void)
   vimInput("g");
   vimInput("g");
   vimInput("0");
+
+  messageCount = 0;
 }
 
 void test_teardown(void) {}
@@ -38,17 +47,59 @@ MU_TEST(test_insert_literal_ctrl_q)
   mu_check(strcmp(vimCommandLineGetText(), "a~b") == 0);
 }
 
+
+// MU_TEST(test_typing_function_command)
+// {
+//   vimInput(":");
+//   vimInput("function! Test()");
+  // TODO: Fix
+  // vimKey("<CR>");
+  // Should get an error message for multiline construct
+//   mu_check(messageCount == 1);
+// }
+// MU_TEST(test_multiline_command_sends_message) 
+// {
+//   mu_check(messageCount == 0);
+//   vimExecute("function! Test()");
+  // Should get an error message for multiline construct
+//   mu_check(messageCount == 1);
+// }
+
+MU_TEST(test_valid_multiline_command)
+{
+  mu_check(messageCount == 0);
+
+  char_u* lines[] = {
+    "function! SomeCommandTest()",
+    "return 42",
+    "endfunction"
+  };
+
+  vimExecuteLines(lines, 3);
+  mu_check(messageCount == 0);
+
+  char_u* result = vimEval("SomeCommandTest()");
+  printf("Got result: %s\n", result);
+  mu_check(strcmp(result, "42") == 0);
+  vim_free(result);
+}
+
 MU_TEST_SUITE(test_suite)
 {
   MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
 
   MU_RUN_TEST(test_insert_literal_ctrl_v);
   MU_RUN_TEST(test_insert_literal_ctrl_q);
+  //MU_RUN_TEST(test_typing_function_command);
+  //MU_RUN_TEST(test_multiline_command_sends_message);
+  MU_RUN_TEST(test_valid_multiline_command);
 }
 
 int main(int argc, char **argv)
 {
   vimInit(argc, argv);
+
+  vimSetMessageCallback(&onMessage);
 
   win_setwidth(5);
   win_setheight(100);

--- a/src/apitest/cmdline.c
+++ b/src/apitest/cmdline.c
@@ -47,7 +47,6 @@ MU_TEST(test_insert_literal_ctrl_q)
   mu_check(strcmp(vimCommandLineGetText(), "a~b") == 0);
 }
 
-
 MU_TEST(test_typing_function_command)
 {
   vimInput(":");
@@ -57,7 +56,7 @@ MU_TEST(test_typing_function_command)
   mu_check(messageCount == 1);
 }
 
-MU_TEST(test_multiline_command_sends_message) 
+MU_TEST(test_multiline_command_sends_message)
 {
   mu_check(messageCount == 0);
   vimExecute("function! Test()");
@@ -69,16 +68,15 @@ MU_TEST(test_valid_multiline_command)
 {
   mu_check(messageCount == 0);
 
-  char_u* lines[] = {
-    "function! SomeCommandTest()",
-    "return 42",
-    "endfunction"
-  };
+  char_u *lines[] = {
+      "function! SomeCommandTest()",
+      "return 42",
+      "endfunction"};
 
   vimExecuteLines(lines, 3);
   mu_check(messageCount == 0);
 
-  char_u* result = vimEval("SomeCommandTest()");
+  char_u *result = vimEval("SomeCommandTest()");
   printf("Got result: %s\n", result);
   mu_check(strcmp(result, "42") == 0);
   vim_free(result);

--- a/src/apitest/minunit.h
+++ b/src/apitest/minunit.h
@@ -24,14 +24,15 @@
 #define MINUNIT_MINUNIT_H
 
 #ifdef __cplusplus
-	extern "C" {
+extern "C"
+{
 #endif
 
 #if defined(_WIN32)
 #include <Windows.h>
 #if defined(_MSC_VER) && _MSC_VER < 1900
-  #define snprintf _snprintf
-  #define __func__ __FUNCTION__
+#define snprintf _snprintf
+#define __func__ __FUNCTION__
 #endif
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
@@ -42,12 +43,12 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
-#include <unistd.h>	/* POSIX flags */
-#include <time.h>	/* clock_gettime(), time() */
-#include <sys/time.h>	/* gethrtime(), gettimeofday() */
-#include <sys/resource.h>
-#include <sys/times.h>
 #include <string.h>
+#include <sys/resource.h>
+#include <sys/time.h> /* gethrtime(), gettimeofday() */
+#include <sys/times.h>
+#include <time.h>   /* clock_gettime(), time() */
+#include <unistd.h> /* POSIX flags */
 
 #if defined(__MACH__) && defined(__APPLE__)
 #include <mach/mach.h>
@@ -58,335 +59,322 @@
 #error "Unable to define timers for an unknown OS."
 #endif
 
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 
 /*  Maximum length of last message */
 #define MINUNIT_MESSAGE_LEN 1024
 /*  Accuracy with which floats are compared */
 #define MINUNIT_EPSILON 1E-12
 
-/*  Misc. counters */
-static int minunit_run = 0;
-static int minunit_assert = 0;
-static int minunit_fail = 0;
-static int minunit_status = 0;
+  /*  Misc. counters */
+  static int minunit_run = 0;
+  static int minunit_assert = 0;
+  static int minunit_fail = 0;
+  static int minunit_status = 0;
 
-/*  Timers */
-static double minunit_real_timer = 0;
-static double minunit_proc_timer = 0;
+  /*  Timers */
+  static double minunit_real_timer = 0;
+  static double minunit_proc_timer = 0;
 
-/*  Last message */
-static char minunit_last_message[MINUNIT_MESSAGE_LEN];
+  /*  Last message */
+  static char minunit_last_message[MINUNIT_MESSAGE_LEN];
 
-/*  Test setup and teardown function pointers */
-static void (*minunit_setup)(void) = NULL;
-static void (*minunit_teardown)(void) = NULL;
+  /*  Test setup and teardown function pointers */
+  static void (*minunit_setup)(void) = NULL;
+  static void (*minunit_teardown)(void) = NULL;
 
 /*  Definitions */
 #define MU_TEST(method_name) static void method_name(void)
 #define MU_TEST_SUITE(suite_name) static void suite_name(void)
 
-#define MU__SAFE_BLOCK(block) do {\
-	block\
-} while(0)
+#define MU__SAFE_BLOCK(block) \
+  do                          \
+  {                           \
+    block                     \
+  } while (0)
 
 /*  Run test suite and unset setup and teardown functions */
-#define MU_RUN_SUITE(suite_name) MU__SAFE_BLOCK(\
-	suite_name();\
-	minunit_setup = NULL;\
-	minunit_teardown = NULL;\
-)
+#define MU_RUN_SUITE(suite_name) MU__SAFE_BLOCK( \
+    suite_name();                                \
+    minunit_setup = NULL;                        \
+    minunit_teardown = NULL;)
 
 /*  Configure setup and teardown functions */
-#define MU_SUITE_CONFIGURE(setup_fun, teardown_fun) MU__SAFE_BLOCK(\
-	minunit_setup = setup_fun;\
-	minunit_teardown = teardown_fun;\
-)
+#define MU_SUITE_CONFIGURE(setup_fun, teardown_fun) MU__SAFE_BLOCK( \
+    minunit_setup = setup_fun;                                      \
+    minunit_teardown = teardown_fun;)
 
 #define STR(X) #X
 #define ASSTR(X) STR(X)
 
 /*  Test runner */
-#define MU_RUN_TEST(test) MU__SAFE_BLOCK(\
-	if (minunit_real_timer==0 && minunit_proc_timer==0) {\
-		minunit_real_timer = mu_timer_real();\
-		minunit_proc_timer = mu_timer_cpu();\
-	}\
-  printf("\n-- START " ASSTR(test) " --\n"); \
-	if (minunit_setup) (*minunit_setup)();\
-	minunit_status = 0;\
-	test();\
-	minunit_run++;\
-	if (minunit_status) {\
-		minunit_fail++;\
-		printf("[FAILED]");\
-		printf("\n%s\n", minunit_last_message);\
-	}\
-	fflush(stdout);\
-	if (minunit_teardown) (*minunit_teardown)();\
-  printf("\n-- END " ASSTR(test) " --\n"); \
-)
+#define MU_RUN_TEST(test) MU__SAFE_BLOCK(                     \
+    if (minunit_real_timer == 0 && minunit_proc_timer == 0) { \
+      minunit_real_timer = mu_timer_real();                   \
+      minunit_proc_timer = mu_timer_cpu();                    \
+    } printf("\n-- START " ASSTR(test) " --\n");              \
+    if (minunit_setup)(*minunit_setup)();                     \
+    minunit_status = 0;                                       \
+    test();                                                   \
+    minunit_run++;                                            \
+    if (minunit_status) {                                     \
+      minunit_fail++;                                         \
+      printf("[FAILED]");                                     \
+      printf("\n%s\n", minunit_last_message);                 \
+    } fflush(stdout);                                         \
+    if (minunit_teardown)(*minunit_teardown)();               \
+    printf("\n-- END " ASSTR(test) " --\n");)
 
 /*  Report */
-#define MU_REPORT() MU__SAFE_BLOCK(\
-	double minunit_end_real_timer;\
-	double minunit_end_proc_timer;\
-	printf("\n\n%d tests, %d assertions, %d failures\n", minunit_run, minunit_assert, minunit_fail);\
-	minunit_end_real_timer = mu_timer_real();\
-	minunit_end_proc_timer = mu_timer_cpu();\
-	printf("\nFinished in %.8f seconds (real) %.8f seconds (proc)\n\n",\
-		minunit_end_real_timer - minunit_real_timer,\
-		minunit_end_proc_timer - minunit_proc_timer);\
-)
+#define MU_REPORT() MU__SAFE_BLOCK(                                                                  \
+    double minunit_end_real_timer;                                                                   \
+    double minunit_end_proc_timer;                                                                   \
+    printf("\n\n%d tests, %d assertions, %d failures\n", minunit_run, minunit_assert, minunit_fail); \
+    minunit_end_real_timer = mu_timer_real();                                                        \
+    minunit_end_proc_timer = mu_timer_cpu();                                                         \
+    printf("\nFinished in %.8f seconds (real) %.8f seconds (proc)\n\n",                              \
+           minunit_end_real_timer - minunit_real_timer,                                              \
+           minunit_end_proc_timer - minunit_proc_timer);)
 
-#define MU_RETURN() MU__SAFE_BLOCK(\
-  return minunit_fail > 0 ? 1 : 0;\
-)
+#define MU_RETURN() MU__SAFE_BLOCK( \
+    return minunit_fail > 0 ? 1 : 0;)
 
 /*  Assertions */
-#define mu_check(test) MU__SAFE_BLOCK(\
-	minunit_assert++;\
-	if (!(test)) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, #test);\
-		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(".\n");\
-	}\
-)
+#define mu_check(test) MU__SAFE_BLOCK(                                                                                     \
+    minunit_assert++;                                                                                                      \
+    if (!(test)) {                                                                                                         \
+      snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, #test); \
+      minunit_status = 1;                                                                                                  \
+      return;                                                                                                              \
+    } else {                                                                                                               \
+      printf(".\n");                                                                                                       \
+    })
 
-#define mu_fail(message) MU__SAFE_BLOCK(\
-	minunit_assert++;\
-	snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, message);\
-	minunit_status = 1;\
-	return;\
-)
+#define mu_fail(message) MU__SAFE_BLOCK(                                                                                   \
+    minunit_assert++;                                                                                                      \
+    snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, message); \
+    minunit_status = 1;                                                                                                    \
+    return;)
 
-#define mu_assert(test, message) MU__SAFE_BLOCK(\
-	minunit_assert++;\
-	if (!(test)) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, message);\
-		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(".\n");\
-	}\
-)
+#define mu_assert(test, message) MU__SAFE_BLOCK(                                                                             \
+    minunit_assert++;                                                                                                        \
+    if (!(test)) {                                                                                                           \
+      snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, __FILE__, __LINE__, message); \
+      minunit_status = 1;                                                                                                    \
+      return;                                                                                                                \
+    } else {                                                                                                                 \
+      printf(".\n");                                                                                                         \
+    })
 
-#define mu_assert_int_eq(expected, result) MU__SAFE_BLOCK(\
-	int minunit_tmp_e;\
-	int minunit_tmp_r;\
-	minunit_assert++;\
-	minunit_tmp_e = (expected);\
-	minunit_tmp_r = (result);\
-	if (minunit_tmp_e != minunit_tmp_r) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %d expected but was %d", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
-		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(".");\
-	}\
-)
+#define mu_assert_int_eq(expected, result) MU__SAFE_BLOCK(                                                                                                            \
+    int minunit_tmp_e;                                                                                                                                                \
+    int minunit_tmp_r;                                                                                                                                                \
+    minunit_assert++;                                                                                                                                                 \
+    minunit_tmp_e = (expected);                                                                                                                                       \
+    minunit_tmp_r = (result);                                                                                                                                         \
+    if (minunit_tmp_e != minunit_tmp_r) {                                                                                                                             \
+      snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %d expected but was %d", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r); \
+      minunit_status = 1;                                                                                                                                             \
+      return;                                                                                                                                                         \
+    } else {                                                                                                                                                          \
+      printf(".");                                                                                                                                                    \
+    })
 
-#define mu_assert_double_eq(expected, result) MU__SAFE_BLOCK(\
-	double minunit_tmp_e;\
-	double minunit_tmp_r;\
-	minunit_assert++;\
-	minunit_tmp_e = (expected);\
-	minunit_tmp_r = (result);\
-	if (fabs(minunit_tmp_e-minunit_tmp_r) > MINUNIT_EPSILON) {\
-		int minunit_significant_figures = 1 - log10(MINUNIT_EPSILON);\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, minunit_significant_figures, minunit_tmp_e, minunit_significant_figures, minunit_tmp_r);\
-		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(".");\
-	}\
-)
+#define mu_assert_double_eq(expected, result) MU__SAFE_BLOCK(                                                                                                                                                                       \
+    double minunit_tmp_e;                                                                                                                                                                                                           \
+    double minunit_tmp_r;                                                                                                                                                                                                           \
+    minunit_assert++;                                                                                                                                                                                                               \
+    minunit_tmp_e = (expected);                                                                                                                                                                                                     \
+    minunit_tmp_r = (result);                                                                                                                                                                                                       \
+    if (fabs(minunit_tmp_e - minunit_tmp_r) > MINUNIT_EPSILON) {                                                                                                                                                                    \
+      int minunit_significant_figures = 1 - log10(MINUNIT_EPSILON);                                                                                                                                                                 \
+      snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, minunit_significant_figures, minunit_tmp_e, minunit_significant_figures, minunit_tmp_r); \
+      minunit_status = 1;                                                                                                                                                                                                           \
+      return;                                                                                                                                                                                                                       \
+    } else {                                                                                                                                                                                                                        \
+      printf(".");                                                                                                                                                                                                                  \
+    })
 
-#define mu_assert_string_eq(expected, result) MU__SAFE_BLOCK(\
-	const char* minunit_tmp_e = expected;\
-	const char* minunit_tmp_r = result;\
-	minunit_assert++;\
-	if (!minunit_tmp_e) {\
-		minunit_tmp_e = "<null pointer>";\
-	}\
-	if (!minunit_tmp_r) {\
-		minunit_tmp_r = "<null pointer>";\
-	}\
-	if(strcmp(minunit_tmp_e, minunit_tmp_r)) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: '%s' expected but was '%s'", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
-		minunit_status = 1;\
-		return;\
-	} else {\
-		printf(".");\
-	}\
-)
+#define mu_assert_string_eq(expected, result) MU__SAFE_BLOCK(                                                                                                             \
+    const char *minunit_tmp_e = expected;                                                                                                                                 \
+    const char *minunit_tmp_r = result;                                                                                                                                   \
+    minunit_assert++;                                                                                                                                                     \
+    if (!minunit_tmp_e) {                                                                                                                                                 \
+      minunit_tmp_e = "<null pointer>";                                                                                                                                   \
+    } if (!minunit_tmp_r) {                                                                                                                                               \
+      minunit_tmp_r = "<null pointer>";                                                                                                                                   \
+    } if (strcmp(minunit_tmp_e, minunit_tmp_r)) {                                                                                                                         \
+      snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: '%s' expected but was '%s'", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r); \
+      minunit_status = 1;                                                                                                                                                 \
+      return;                                                                                                                                                             \
+    } else {                                                                                                                                                              \
+      printf(".");                                                                                                                                                        \
+    })
 
-/*
+  /*
  * The following two functions were written by David Robert Nadeau
  * from http://NadeauSoftware.com/ and distributed under the
  * Creative Commons Attribution 3.0 Unported License
  */
 
-/**
+  /**
  * Returns the real time, in seconds, or -1.0 if an error occurred.
  *
  * Time is measured since an arbitrary and OS-dependent start time.
  * The returned real time is only useful for computing an elapsed time
  * between two calls to this function.
  */
-static double mu_timer_real(void)
-{
+  static double mu_timer_real(void)
+  {
 #if defined(_WIN32)
-	/* Windows 2000 and later. ---------------------------------- */
-	LARGE_INTEGER Time;
-	LARGE_INTEGER Frequency;
-	
-	QueryPerformanceFrequency(&Frequency);
-	QueryPerformanceCounter(&Time);
-	
-	Time.QuadPart *= 1000000;
-	Time.QuadPart /= Frequency.QuadPart;
-	
-	return (double)Time.QuadPart / 1000000.0;
+    /* Windows 2000 and later. ---------------------------------- */
+    LARGE_INTEGER Time;
+    LARGE_INTEGER Frequency;
+
+    QueryPerformanceFrequency(&Frequency);
+    QueryPerformanceCounter(&Time);
+
+    Time.QuadPart *= 1000000;
+    Time.QuadPart /= Frequency.QuadPart;
+
+    return (double)Time.QuadPart / 1000000.0;
 
 #elif (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))
-	/* HP-UX, Solaris. ------------------------------------------ */
-	return (double)gethrtime( ) / 1000000000.0;
+  /* HP-UX, Solaris. ------------------------------------------ */
+  return (double)gethrtime() / 1000000000.0;
 
 #elif defined(__MACH__) && defined(__APPLE__)
-	/* OSX. ----------------------------------------------------- */
-	static double timeConvert = 0.0;
-	if ( timeConvert == 0.0 )
-	{
-		mach_timebase_info_data_t timeBase;
-		(void)mach_timebase_info( &timeBase );
-		timeConvert = (double)timeBase.numer /
-			(double)timeBase.denom /
-			1000000000.0;
-	}
-	return (double)mach_absolute_time( ) * timeConvert;
+  /* OSX. ----------------------------------------------------- */
+  static double timeConvert = 0.0;
+  if (timeConvert == 0.0)
+  {
+    mach_timebase_info_data_t timeBase;
+    (void)mach_timebase_info(&timeBase);
+    timeConvert = (double)timeBase.numer /
+                  (double)timeBase.denom /
+                  1000000000.0;
+  }
+  return (double)mach_absolute_time() * timeConvert;
 
 #elif defined(_POSIX_VERSION)
-	/* POSIX. --------------------------------------------------- */
-	struct timeval tm;
+  /* POSIX. --------------------------------------------------- */
+  struct timeval tm;
 #if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
-	{
-		struct timespec ts;
+  {
+    struct timespec ts;
 #if defined(CLOCK_MONOTONIC_PRECISE)
-		/* BSD. --------------------------------------------- */
-		const clockid_t id = CLOCK_MONOTONIC_PRECISE;
+    /* BSD. --------------------------------------------- */
+    const clockid_t id = CLOCK_MONOTONIC_PRECISE;
 #elif defined(CLOCK_MONOTONIC_RAW)
-		/* Linux. ------------------------------------------- */
-		const clockid_t id = CLOCK_MONOTONIC_RAW;
+    /* Linux. ------------------------------------------- */
+    const clockid_t id = CLOCK_MONOTONIC_RAW;
 #elif defined(CLOCK_HIGHRES)
-		/* Solaris. ----------------------------------------- */
-		const clockid_t id = CLOCK_HIGHRES;
+    /* Solaris. ----------------------------------------- */
+    const clockid_t id = CLOCK_HIGHRES;
 #elif defined(CLOCK_MONOTONIC)
-		/* AIX, BSD, Linux, POSIX, Solaris. ----------------- */
-		const clockid_t id = CLOCK_MONOTONIC;
+    /* AIX, BSD, Linux, POSIX, Solaris. ----------------- */
+    const clockid_t id = CLOCK_MONOTONIC;
 #elif defined(CLOCK_REALTIME)
-		/* AIX, BSD, HP-UX, Linux, POSIX. ------------------- */
-		const clockid_t id = CLOCK_REALTIME;
+    /* AIX, BSD, HP-UX, Linux, POSIX. ------------------- */
+    const clockid_t id = CLOCK_REALTIME;
 #else
-		const clockid_t id = (clockid_t)-1;	/* Unknown. */
+    const clockid_t id = (clockid_t)-1; /* Unknown. */
 #endif /* CLOCK_* */
-		if ( id != (clockid_t)-1 && clock_gettime( id, &ts ) != -1 )
-			return (double)ts.tv_sec +
-				(double)ts.tv_nsec / 1000000000.0;
-		/* Fall thru. */
-	}
+    if (id != (clockid_t)-1 && clock_gettime(id, &ts) != -1)
+      return (double)ts.tv_sec +
+             (double)ts.tv_nsec / 1000000000.0;
+    /* Fall thru. */
+  }
 #endif /* _POSIX_TIMERS */
 
-	/* AIX, BSD, Cygwin, HP-UX, Linux, OSX, POSIX, Solaris. ----- */
-	gettimeofday( &tm, NULL );
-	return (double)tm.tv_sec + (double)tm.tv_usec / 1000000.0;
+  /* AIX, BSD, Cygwin, HP-UX, Linux, OSX, POSIX, Solaris. ----- */
+  gettimeofday(&tm, NULL);
+  return (double)tm.tv_sec + (double)tm.tv_usec / 1000000.0;
 #else
-	return -1.0;		/* Failed. */
+  return -1.0; /* Failed. */
 #endif
-}
+  }
 
-/**
+  /**
  * Returns the amount of CPU time used by the current process,
  * in seconds, or -1.0 if an error occurred.
  */
-static double mu_timer_cpu(void)
-{
+  static double mu_timer_cpu(void)
+  {
 #if defined(_WIN32)
-	/* Windows -------------------------------------------------- */
-	FILETIME createTime;
-	FILETIME exitTime;
-	FILETIME kernelTime;
-	FILETIME userTime;
+    /* Windows -------------------------------------------------- */
+    FILETIME createTime;
+    FILETIME exitTime;
+    FILETIME kernelTime;
+    FILETIME userTime;
 
-	/* This approach has a resolution of 1/64 second. Unfortunately, Windows' API does not offer better */
-	if ( GetProcessTimes( GetCurrentProcess( ),
-		&createTime, &exitTime, &kernelTime, &userTime ) != 0 )
-	{
-		ULARGE_INTEGER userSystemTime;
-		memcpy(&userSystemTime, &userTime, sizeof(ULARGE_INTEGER));
-		return (double)userSystemTime.QuadPart / 10000000.0;
-	}
+    /* This approach has a resolution of 1/64 second. Unfortunately, Windows' API does not offer better */
+    if (GetProcessTimes(GetCurrentProcess(),
+                        &createTime, &exitTime, &kernelTime, &userTime) != 0)
+    {
+      ULARGE_INTEGER userSystemTime;
+      memcpy(&userSystemTime, &userTime, sizeof(ULARGE_INTEGER));
+      return (double)userSystemTime.QuadPart / 10000000.0;
+    }
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
-	/* AIX, BSD, Cygwin, HP-UX, Linux, OSX, and Solaris --------- */
+  /* AIX, BSD, Cygwin, HP-UX, Linux, OSX, and Solaris --------- */
 
 #if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
-	/* Prefer high-res POSIX timers, when available. */
-	{
-		clockid_t id;
-		struct timespec ts;
+  /* Prefer high-res POSIX timers, when available. */
+  {
+    clockid_t id;
+    struct timespec ts;
 #if _POSIX_CPUTIME > 0
-		/* Clock ids vary by OS.  Query the id, if possible. */
-		if ( clock_getcpuclockid( 0, &id ) == -1 )
+    /* Clock ids vary by OS.  Query the id, if possible. */
+    if (clock_getcpuclockid(0, &id) == -1)
 #endif
 #if defined(CLOCK_PROCESS_CPUTIME_ID)
-			/* Use known clock id for AIX, Linux, or Solaris. */
-			id = CLOCK_PROCESS_CPUTIME_ID;
+      /* Use known clock id for AIX, Linux, or Solaris. */
+      id = CLOCK_PROCESS_CPUTIME_ID;
 #elif defined(CLOCK_VIRTUAL)
-			/* Use known clock id for BSD or HP-UX. */
-			id = CLOCK_VIRTUAL;
+    /* Use known clock id for BSD or HP-UX. */
+    id = CLOCK_VIRTUAL;
 #else
-			id = (clockid_t)-1;
+    id = (clockid_t)-1;
 #endif
-		if ( id != (clockid_t)-1 && clock_gettime( id, &ts ) != -1 )
-			return (double)ts.tv_sec +
-				(double)ts.tv_nsec / 1000000000.0;
-	}
+    if (id != (clockid_t)-1 && clock_gettime(id, &ts) != -1)
+      return (double)ts.tv_sec +
+             (double)ts.tv_nsec / 1000000000.0;
+  }
 #endif
 
 #if defined(RUSAGE_SELF)
-	{
-		struct rusage rusage;
-		if ( getrusage( RUSAGE_SELF, &rusage ) != -1 )
-			return (double)rusage.ru_utime.tv_sec +
-				(double)rusage.ru_utime.tv_usec / 1000000.0;
-	}
+  {
+    struct rusage rusage;
+    if (getrusage(RUSAGE_SELF, &rusage) != -1)
+      return (double)rusage.ru_utime.tv_sec +
+             (double)rusage.ru_utime.tv_usec / 1000000.0;
+  }
 #endif
 
 #if defined(_SC_CLK_TCK)
-	{
-		const double ticks = (double)sysconf( _SC_CLK_TCK );
-		struct tms tms;
-		if ( times( &tms ) != (clock_t)-1 )
-			return (double)tms.tms_utime / ticks;
-	}
+  {
+    const double ticks = (double)sysconf(_SC_CLK_TCK);
+    struct tms tms;
+    if (times(&tms) != (clock_t)-1)
+      return (double)tms.tms_utime / ticks;
+  }
 #endif
 
 #if defined(CLOCKS_PER_SEC)
-	{
-		clock_t cl = clock( );
-		if ( cl != (clock_t)-1 )
-			return (double)cl / (double)CLOCKS_PER_SEC;
-	}
+  {
+    clock_t cl = clock();
+    if (cl != (clock_t)-1)
+      return (double)cl / (double)CLOCKS_PER_SEC;
+  }
 #endif
 
 #endif
 
-	return -1;		/* Failed. */
-}
+    return -1; /* Failed. */
+  }
 
 #ifdef __cplusplus
 }

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -478,13 +478,13 @@ void vimExecuteLines(char_u **lines, int lineCount)
   libvim_execute_cookie_T cookie;
   cookie.lines = lines;
   cookie.lineCount = lineCount;
-  cookie.nextLine = 1;
+  cookie.nextLine = 0;
 
   do_cmdline(
-      lines[0],
+      NULL,
       &vimExecute_getLine,
       &cookie,
-      DOCMD_VERBOSE | DOCMD_NOWAIT | DOCMD_KEYTYPED);
+      DOCMD_VERBOSE | DOCMD_REPEAT | DOCMD_NOWAIT | DOCMD_KEYTYPED);
 }
 
 void vimExecute(char_u *cmd)

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -475,6 +475,11 @@ char_u *vimExecute_getLine(int line, void *cookie, int indent)
 
 void vimExecuteLines(char_u **lines, int lineCount)
 {
+  if (lines == NULL || lineCount <= 0)
+  {
+    return;
+  }
+
   libvim_execute_cookie_T cookie;
   cookie.lines = lines;
   cookie.lineCount = lineCount;

--- a/src/libvim.c
+++ b/src/libvim.c
@@ -450,43 +450,47 @@ void vimSetStopSearchHighlightCallback(VoidCallback callback)
   stopSearchHighlightCallback = callback;
 }
 
-typedef struct {
-	char_u **lines;
+typedef struct
+{
+  char_u **lines;
   int lineCount;
-	int nextLine;
+  int nextLine;
 } libvim_execute_cookie_T;
 
-char_u* vimExecute_getLine(int line, void* cookie, int indent) {
-  libvim_execute_cookie_T* context = (libvim_execute_cookie_T*)cookie;
+char_u *vimExecute_getLine(int line, void *cookie, int indent)
+{
+  libvim_execute_cookie_T *context = (libvim_execute_cookie_T *)cookie;
 
-	printf("vimExecute_getLine: %d current: %d\n", line, context->nextLine);
-  if (context->nextLine >= context->lineCount) {
+  if (context->nextLine >= context->lineCount)
+  {
     return NULL;
-  } else {
-		int nextLine = context->nextLine;
-		context->nextLine++;
-		printf("nextLine: %d line: %s\n", nextLine, context->lines[nextLine]);
+  }
+  else
+  {
+    int nextLine = context->nextLine;
+    context->nextLine++;
     return strdup(context->lines[nextLine]);
   }
 };
 
-void vimExecuteLines(char_u **lines, int lineCount) {
+void vimExecuteLines(char_u **lines, int lineCount)
+{
   libvim_execute_cookie_T cookie;
   cookie.lines = lines;
   cookie.lineCount = lineCount;
-	cookie.nextLine = 1;
+  cookie.nextLine = 1;
 
-	do_cmdline(
-    lines[0],
-    &vimExecute_getLine,
-    &cookie,
-                    DOCMD_VERBOSE | DOCMD_NOWAIT | DOCMD_KEYTYPED
-  );
+  do_cmdline(
+      lines[0],
+      &vimExecute_getLine,
+      &cookie,
+      DOCMD_VERBOSE | DOCMD_NOWAIT | DOCMD_KEYTYPED);
 }
 
-void vimExecute(char_u *cmd) { 
+void vimExecute(char_u *cmd)
+{
 
-  char_u* lines[] = {cmd};
+  char_u *lines[] = {cmd};
 
   vimExecuteLines(lines, 1);
 };

--- a/src/libvim.h
+++ b/src/libvim.h
@@ -191,6 +191,8 @@ void vimKey(char_u *key);
  */
 void vimExecute(char_u *cmd);
 
+void vimExecuteLines(char_u **lines, int lineCount);
+
 /***
  * Auto-indent
  ***/

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2269,10 +2269,13 @@ void ex_function(exarg_T *eap)
     else
     {
       vim_free(line_to_free);
-      if (eap->getline == NULL)
-        theline = getcmdline(':', 0L, indent);
-      else
+      if (eap->getline == NULL) {
+				// libvim: Only allow :function in the context of source/vimExecuteLines
+				emsg(_("E126: Missing :endfunction"));
+				goto erret;
+      } else {
         theline = eap->getline(':', eap->cookie, indent);
+			}
       line_to_free = theline;
     }
     if (KeyTyped)

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2269,13 +2269,16 @@ void ex_function(exarg_T *eap)
     else
     {
       vim_free(line_to_free);
-      if (eap->getline == NULL) {
-				// libvim: Only allow :function in the context of source/vimExecuteLines
-				emsg(_("E126: Missing :endfunction"));
-				goto erret;
-      } else {
+      if (eap->getline == NULL)
+      {
+        // libvim: Only allow :function in the context of source/vimExecuteLines
+        emsg(_("E126: Missing :endfunction"));
+        goto erret;
+      }
+      else
+      {
         theline = eap->getline(':', eap->cookie, indent);
-			}
+      }
       line_to_free = theline;
     }
     if (KeyTyped)


### PR DESCRIPTION
Fix crash when using `function!` in experimental.viml (or via command line) in Onivim

- When parsing multiple lines, giving `do_cmdline_cmd` context about additional lines - this is important for `:function`, `:while`, etc.
- When working in the command line, don't handle multiple lines - prevent a crash in `:function` in this case.

__Todo:__
- [x] Ignore null
- [x] Handle multiple functions